### PR TITLE
chore: authorize alex@phone SSH key

### DIFF
--- a/hosts/common/global/users/alex/default.nix
+++ b/hosts/common/global/users/alex/default.nix
@@ -21,6 +21,7 @@
         "no-touch-required sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIP7VVX7OyA4eYm2nzJMmRl4EI8seJ3pTyUIuenTGivrcAAAAD3NzaDpzeXN0ZW0tYXV0aA== YubiKey840-system-auth"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAEGkHcMirY9luPZudrCkXEL9EDnnrRGKPv8uEqChtdl alex@terminus"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPXQH5gI49qNuwiTigLDbZJ8l0NNl4OksmIXV/TRyGi6 alex@saruman"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAD/cB01DFcbp6ZwCPdYw8Ayc0Vd1TOCiuVlWdpMsLBW alex@phone"
       ];
       extraGroups = [ "wheel" "audio" "video" "plugdev" "dialout" "docker" "networkmanager" "adm" ];
     };


### PR DESCRIPTION
## Summary

Adds a new ed25519 SSH key (`alex@phone`) to alex's authorized keys on every NixOS host via `hosts/common/global/users/alex/default.nix`. Scoped to user `alex` only, not root.

## Test plan

- [x] `nix flake check` passes
- [ ] After merge + auto-deploy, SSH from phone to any host succeeds with this key

🤖 Generated with [Claude Code](https://claude.com/claude-code)