### PR TITLE
Phase 2: obsidian-headless + vault MCP on saruman

### DIFF
--- a/hosts/common/optional/roles/server/default.nix
+++ b/hosts/common/optional/roles/server/default.nix
@@ -27,5 +27,7 @@
     ./kokoro.nix
     ./auto-deploy.nix
     ./agent-memory
+    ./obsidian-headless
+    ./vault-mcp
   ];
 }

--- a/hosts/common/optional/roles/server/obsidian-headless/default.nix
+++ b/hosts/common/optional/roles/server/obsidian-headless/default.nix
@@ -1,0 +1,75 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.obsidian-headless;
+in
+{
+  options.obsidian-headless = {
+    enable = lib.mkEnableOption "Obsidian Sync headless daemon (proprietary, requires a paid Obsidian Sync subscription)";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "alex";
+      description = ''
+        UNIX user that owns the vault and runs the sync daemon. The user's
+        Obsidian Sync credentials live at $XDG_CONFIG_HOME/obsidian-headless/.
+        First-time setup is interactive: ssh in as this user and run
+        `ob login` once. The daemon won't start successfully until that file
+        exists.
+      '';
+    };
+
+    vaultPath = lib.mkOption {
+      type = lib.types.path;
+      default = "/home/alex/obsidian/Barrow-Downs";
+      description = "Absolute path to the on-disk vault directory the daemon keeps in sync.";
+    };
+
+    configDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/home/alex/.config/obsidian-headless";
+      description = ''
+        Where `ob` reads/writes its session token and per-vault state. On the
+        chosen user's /home (which is its own btrfs subvol on saruman), so
+        this naturally survives reboots without an impermanence rule.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Make `ob` available in the user's shell so they can run `ob login`,
+    # `ob sync-status`, etc. manually.
+    environment.systemPackages = [ pkgs.obsidian-headless ];
+
+    systemd.services.obsidian-headless = {
+      description = "Obsidian Sync headless daemon (continuous sync)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # Only attempt to run if the user has completed the interactive
+      # `ob login` flow. Prevents a tight crash loop before bootstrap.
+      unitConfig.ConditionPathExists = "${cfg.configDir}";
+
+      environment = {
+        # XDG_CONFIG_HOME drives where `ob` looks for its session/state.
+        XDG_CONFIG_HOME = builtins.toString (builtins.dirOf cfg.configDir);
+      };
+
+      serviceConfig = {
+        ExecStart = "${pkgs.obsidian-headless}/bin/ob sync --continuous --path ${cfg.vaultPath}";
+        User = cfg.user;
+        Group = "users";
+        Restart = "on-failure";
+        RestartSec = "10s";
+
+        # Modest hardening — service needs to write to the vault dir and the
+        # config dir, both under /home.
+        ProtectSystem = "strict";
+        ProtectHome = false; # we WANT access to /home/<user>/...
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ReadWritePaths = [ cfg.vaultPath cfg.configDir ];
+      };
+    };
+  };
+}

--- a/hosts/common/optional/roles/server/vault-mcp/default.nix
+++ b/hosts/common/optional/roles/server/vault-mcp/default.nix
@@ -1,0 +1,86 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.vault-mcp;
+in
+{
+  options.vault-mcp = {
+    enable = lib.mkEnableOption "vault MCP gateway (read/write/search over an Obsidian vault directory)";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4281;
+      description = "TCP port the vault MCP gateway listens on (tailnet IP only).";
+    };
+
+    bindIp = lib.mkOption {
+      type = lib.types.str;
+      default = "auto";
+      description = ''
+        IPv4 to bind. "auto" resolves the host's tailnet IP via
+        `tailscale ip -4` at service start.
+      '';
+    };
+
+    tailnetInterface = lib.mkOption {
+      type = lib.types.str;
+      default = "tailscale0";
+      description = "Interface on which to open the MCP port in the firewall.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "alex";
+      description = ''
+        User to run vault-mcp as. Must have read+write access to the vault
+        directory. On saruman this is `alex`, the same user that owns the
+        vault and runs obsidian-headless.
+      '';
+    };
+
+    vaultRoot = lib.mkOption {
+      type = lib.types.path;
+      default = "/home/alex/obsidian/Barrow-Downs";
+      description = "Absolute path to the on-disk vault directory.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    sops.secrets.vault_mcp_tokens = {
+      owner = cfg.user;
+      group = "users";
+      mode = "0400";
+    };
+
+    systemd.services.vault-mcp = {
+      description = "Vault MCP gateway (Obsidian vault on disk)";
+      after = [ "network-online.target" "tailscaled.service" ];
+      wants = [ "network-online.target" "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ config.services.tailscale.package ];
+
+      environment = {
+        VAULT_MCP_BIND_IP = cfg.bindIp;
+        VAULT_MCP_PORT = toString cfg.port;
+        VAULT_MCP_ROOT = builtins.toString cfg.vaultRoot;
+        VAULT_MCP_TOKENS_FILE = config.sops.secrets.vault_mcp_tokens.path;
+      };
+
+      serviceConfig = {
+        ExecStart = "${pkgs.vault-mcp}/bin/vault-mcp";
+        User = cfg.user;
+        Group = "users";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = false;  # vault lives under /home
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ReadWritePaths = [ cfg.vaultRoot ];
+      };
+    };
+
+    networking.firewall.interfaces.${cfg.tailnetInterface}.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/hosts/saruman/configuration.nix
+++ b/hosts/saruman/configuration.nix
@@ -27,6 +27,8 @@
   auto-deploy.enable = true;
   tailscale-server.enable = true;
   agent-memory.enable = true;
+  obsidian-headless.enable = true;
+  vault-mcp.enable = true;
 
 
   boot.loader.systemd-boot.enable = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,4 +2,6 @@
 {
   ironclaw = pkgs.callPackage ./ironclaw { rustPlatform = pkgs.unstable.rustPlatform; };
   agent-memory-mcp = pkgs.callPackage ./agent-memory-mcp { python3 = pkgs.python3; };
+  obsidian-headless = pkgs.callPackage ./obsidian-headless { };
+  vault-mcp = pkgs.callPackage ./vault-mcp { python3 = pkgs.python3; };
 }

--- a/pkgs/obsidian-headless/default.nix
+++ b/pkgs/obsidian-headless/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchurl
+, buildNpmPackage
+, nodejs_22
+, python3
+, makeWrapper
+}:
+
+buildNpmPackage rec {
+  pname = "obsidian-headless";
+  version = "0.0.8";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/obsidian-headless/-/obsidian-headless-${version}.tgz";
+    hash = "sha256-+fg6tr69/7n73KhlJxAb4ujMOvH64hLwIt/6MeAiNtU=";
+  };
+
+  # The upstream tarball doesn't ship a lock file. We generated one once via
+  # `npm install --package-lock-only` against the published package.json and
+  # check it in here. Refresh by re-running and updating npmDepsHash.
+  postPatch = ''
+    cp ${./package-lock.json} ./package-lock.json
+  '';
+
+  npmDepsHash = "sha256-/g3PV+VJ7zotOn70a3J6lJR5Bz0v24vyI540Pe10MJI=";
+
+  nodejs = nodejs_22;
+
+  # No build step — cli.js is already a bundled artifact. Just install.
+  dontNpmBuild = true;
+
+  # better-sqlite3 ships a prebuilt binary for our triple; if it falls back to
+  # build-from-source it needs python3 + a C++ toolchain (in stdenv already).
+  nativeBuildInputs = [ python3 makeWrapper ];
+
+  # buildNpmPackage's default install lays out node_modules + bin under
+  # $out/lib/node_modules/<pname>; the `bin` field in package.json
+  # ("ob" -> "cli.js") creates $out/bin/ob automatically. We just need to
+  # ensure node is reachable on PATH for the shebang.
+  postInstall = ''
+    wrapProgram $out/bin/ob \
+      --prefix PATH : ${lib.makeBinPath [ nodejs_22 ]}
+  '';
+
+  meta = with lib; {
+    description = "Headless Obsidian Sync client (Dynalist Inc.) — pure sync daemon, no GUI";
+    homepage = "https://github.com/obsidianmd/obsidian-headless";
+    license = licenses.unfree;
+    mainProgram = "ob";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/obsidian-headless/package-lock.json
+++ b/pkgs/obsidian-headless/package-lock.json
@@ -1,0 +1,493 @@
+{
+	"name": "obsidian-headless",
+	"version": "0.0.8",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "obsidian-headless",
+			"version": "0.0.8",
+			"cpu": [
+				"x64",
+				"arm64"
+			],
+			"license": "UNLICENSED",
+			"os": [
+				"darwin",
+				"linux",
+				"win32"
+			],
+			"dependencies": {
+				"better-sqlite3": "12.6.2",
+				"commander": "14.0.3"
+			},
+			"bin": {
+				"ob": "cli.js"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/better-sqlite3": {
+			"version": "12.6.2",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+			"integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.1"
+			},
+			"engines": {
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
+			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"license": "ISC"
+		},
+		"node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"license": "(MIT OR WTFPL)",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"license": "MIT"
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
+		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"license": "MIT"
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"license": "ISC"
+		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"license": "MIT"
+		},
+		"node_modules/napi-build-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"license": "MIT"
+		},
+		"node_modules/node-abi": {
+			"version": "3.92.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^2.0.0",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		}
+	}
+}

--- a/pkgs/obsidian-headless/package.json
+++ b/pkgs/obsidian-headless/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "obsidian-headless",
+	"version": "0.0.8",
+	"description": "Headless client for Obsidian services",
+	"main": "cli.js",
+	"bin": {
+		"ob": "cli.js"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"os": [
+		"darwin",
+		"linux",
+		"win32"
+	],
+	"cpu": [
+		"x64",
+		"arm64"
+	],
+	"files": [
+		"cli.js",
+		"btime",
+		"package.json",
+		"README.md"
+	],
+	"keywords": [
+		"obsidian",
+		"sync",
+		"vault",
+		"markdown",
+		"notes"
+	],
+	"homepage": "https://obsidian.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/obsidianmd/obsidian-headless"
+	},
+	"author": "Dynalist Inc.",
+	"license": "UNLICENSED",
+	"dependencies": {
+		"better-sqlite3": "12.6.2",
+		"commander": "14.0.3"
+	}
+}

--- a/pkgs/vault-mcp/default.nix
+++ b/pkgs/vault-mcp/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "vault-mcp";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  dependencies = with python3.pkgs; [
+    mcp
+    starlette
+    uvicorn
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "MCP server fronting an on-disk Obsidian vault";
+    license = licenses.mit;
+    mainProgram = "vault-mcp";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/vault-mcp/pyproject.toml
+++ b/pkgs/vault-mcp/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vault-mcp"
+version = "0.1.0"
+description = "MCP server fronting an Obsidian vault on disk"
+requires-python = ">=3.11"
+dependencies = [
+  "mcp>=1.15",
+  "starlette>=0.47",
+  "uvicorn>=0.35",
+]
+
+[project.scripts]
+vault-mcp = "vault_mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["vault_mcp*"]

--- a/pkgs/vault-mcp/vault_mcp/server.py
+++ b/pkgs/vault-mcp/vault_mcp/server.py
@@ -1,0 +1,372 @@
+"""Vault MCP server.
+
+Exposes read/write/list/search tools over an on-disk Obsidian vault. Lives
+alongside an obsidian-headless daemon that keeps the directory in sync with
+Obsidian Sync, but does not depend on it — operates directly on the file
+tree.
+
+Defense in depth: tailnet-only binding, bearer-token auth, and per-call path
+sanitization that refuses anything resolving outside the vault root.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+log = logging.getLogger("vault_mcp")
+
+# Files/dirs the server never touches even if asked. .obsidian holds the
+# vault's app config + sync state; we deliberately don't let agents poke it.
+SKIP_PREFIXES = (".obsidian", ".trash", ".git")
+TEXT_EXTENSIONS = (".md", ".canvas", ".txt")
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+class Config:
+    def __init__(self) -> None:
+        self.bind_ip = os.environ.get("VAULT_MCP_BIND_IP", "auto")
+        self.port = int(os.environ.get("VAULT_MCP_PORT", "4281"))
+        self.vault_root = Path(os.environ["VAULT_MCP_ROOT"]).resolve()
+        self.tokens_file = os.environ["VAULT_MCP_TOKENS_FILE"]
+        self.max_read_bytes = int(os.environ.get("VAULT_MCP_MAX_READ_BYTES", "5242880"))  # 5 MiB
+        if not self.vault_root.is_dir():
+            raise SystemExit(f"VAULT_MCP_ROOT={self.vault_root} is not a directory")
+
+    def resolve_bind_ip(self) -> str:
+        if self.bind_ip != "auto":
+            return self.bind_ip
+        r = subprocess.run(
+            ["tailscale", "ip", "-4"], capture_output=True, text=True, check=True
+        )
+        return r.stdout.strip().splitlines()[0]
+
+
+def load_tokens(path: str) -> dict[str, str]:
+    with open(path) as f:
+        raw = json.load(f)
+    tokens = raw.get("tokens", raw)
+    if not isinstance(tokens, dict) or not tokens:
+        raise SystemExit(f"{path}: expected non-empty token map")
+    return {tok: client for client, tok in tokens.items()}
+
+
+CFG: Config | None = None
+TOKENS_BY_HEX: dict[str, str] = {}
+
+
+# ── path safety ──────────────────────────────────────────────────────────────
+
+def safe_join(rel: str) -> Path:
+    """Resolve `rel` under the vault root, refusing anything that escapes.
+
+    Rejects: absolute paths, paths whose resolved form leaves the vault,
+    symlinks that escape, .obsidian/.trash/.git locations.
+    """
+    assert CFG is not None
+    rel = rel.lstrip("/")
+    candidate = (CFG.vault_root / rel).resolve()
+    try:
+        candidate.relative_to(CFG.vault_root)
+    except ValueError as e:
+        raise ValueError(f"path '{rel}' escapes the vault root") from e
+    parts = candidate.relative_to(CFG.vault_root).parts
+    if parts and parts[0] in SKIP_PREFIXES:
+        raise ValueError(f"path '{rel}' targets a protected directory ({parts[0]})")
+    return candidate
+
+
+def iter_notes(folder: Path | None = None):
+    """Yield Path objects for every text file under the vault (or a subfolder),
+    skipping SKIP_PREFIXES and any other dotfiles.
+    """
+    assert CFG is not None
+    base = folder or CFG.vault_root
+    for p in base.rglob("*"):
+        if not p.is_file():
+            continue
+        rel_parts = p.relative_to(CFG.vault_root).parts
+        if any(part.startswith(".") for part in rel_parts):
+            continue
+        if any(rel_parts[0] == sp for sp in SKIP_PREFIXES):
+            continue
+        if p.suffix.lower() in TEXT_EXTENSIONS:
+            yield p
+
+
+def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    """Best-effort YAML-like frontmatter parse. Returns (metadata, body).
+    Avoids a YAML dependency by treating the frontmatter as simple key:value
+    pairs; nested structures are returned as raw strings.
+    """
+    m = FRONTMATTER_RE.match(content)
+    if not m:
+        return {}, content
+    raw = m.group(1)
+    meta: dict[str, Any] = {}
+    for line in raw.splitlines():
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        meta[key.strip()] = val.strip().strip('"').strip("'")
+    return meta, content[m.end():]
+
+
+# ── auth middleware ───────────────────────────────────────────────────────────
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        if not auth.lower().startswith("bearer "):
+            return JSONResponse({"error": "missing bearer token"}, status_code=401)
+        token = auth.split(" ", 1)[1].strip()
+        client = TOKENS_BY_HEX.get(token)
+        if client is None:
+            return JSONResponse({"error": "invalid token"}, status_code=401)
+        request.state.client = client
+        return await call_next(request)
+
+
+# ── MCP server + tools ────────────────────────────────────────────────────────
+
+mcp = FastMCP("vault")
+
+
+@mcp.tool()
+async def vault_read(path: str) -> dict[str, Any]:
+    """Read a note from the vault. Path is relative to the vault root.
+
+    Returns `{path, content, frontmatter, size, mtime}`. Content is truncated
+    if the file exceeds the server's max-read-bytes limit (default 5 MiB).
+    """
+    assert CFG is not None
+    target = safe_join(path)
+    if not target.exists():
+        return {"error": f"not found: {path}"}
+    if not target.is_file():
+        return {"error": f"not a file: {path}"}
+    stat = target.stat()
+    truncated = False
+    raw = target.read_bytes()
+    if len(raw) > CFG.max_read_bytes:
+        raw = raw[: CFG.max_read_bytes]
+        truncated = True
+    content = raw.decode("utf-8", errors="replace")
+    fm, body = parse_frontmatter(content)
+    return {
+        "path": str(target.relative_to(CFG.vault_root)),
+        "content": content,
+        "body": body,
+        "frontmatter": fm,
+        "size": stat.st_size,
+        "mtime": stat.st_mtime,
+        "truncated": truncated,
+    }
+
+
+@mcp.tool()
+async def vault_write(path: str, content: str, overwrite: bool = False) -> dict[str, Any]:
+    """Create or overwrite a note. Refuses to overwrite an existing file unless
+    `overwrite=True`. Auto-creates parent directories.
+
+    Returns `{path, bytes_written, created}`.
+    """
+    target = safe_join(path)
+    existed = target.exists()
+    if existed and not overwrite:
+        return {"error": f"file exists; pass overwrite=true to replace: {path}"}
+    target.parent.mkdir(parents=True, exist_ok=True)
+    data = content.encode("utf-8")
+    target.write_bytes(data)
+    assert CFG is not None
+    return {
+        "path": str(target.relative_to(CFG.vault_root)),
+        "bytes_written": len(data),
+        "created": not existed,
+    }
+
+
+@mcp.tool()
+async def vault_append(path: str, content: str, separator: str = "\n") -> dict[str, Any]:
+    """Append content to a note. If the file doesn't exist, creates it (no
+    separator on first write). Useful for journal/log-style notes.
+
+    Returns `{path, bytes_appended, created}`.
+    """
+    target = safe_join(path)
+    existed = target.exists()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("ab") as f:
+        if existed and not target.read_bytes().endswith(separator.encode("utf-8")):
+            f.write(separator.encode("utf-8"))
+        bytes_written = f.write(content.encode("utf-8"))
+    assert CFG is not None
+    return {
+        "path": str(target.relative_to(CFG.vault_root)),
+        "bytes_appended": bytes_written,
+        "created": not existed,
+    }
+
+
+@mcp.tool()
+async def vault_list(folder: str | None = None, limit: int = 200) -> list[dict[str, Any]]:
+    """List notes in the vault (or under a subfolder). Returns up to `limit`
+    entries with `{path, size, mtime}`. Excludes .obsidian/.trash/.git and
+    other dotfiles.
+    """
+    assert CFG is not None
+    base = safe_join(folder) if folder else CFG.vault_root
+    out: list[dict[str, Any]] = []
+    for p in iter_notes(base):
+        stat = p.stat()
+        out.append({
+            "path": str(p.relative_to(CFG.vault_root)),
+            "size": stat.st_size,
+            "mtime": stat.st_mtime,
+        })
+        if len(out) >= limit:
+            break
+    out.sort(key=lambda r: r["mtime"], reverse=True)
+    return out
+
+
+@mcp.tool()
+async def vault_search(
+    query: str,
+    folder: str | None = None,
+    case_insensitive: bool = True,
+    limit: int = 50,
+    snippet_chars: int = 160,
+) -> list[dict[str, Any]]:
+    """Substring search across vault notes. Returns up to `limit` hits with
+    `{path, line, snippet}`. For semantic search, see the agent-memory MCP
+    (separate service).
+    """
+    assert CFG is not None
+    base = safe_join(folder) if folder else CFG.vault_root
+    flags = re.IGNORECASE if case_insensitive else 0
+    pat = re.compile(re.escape(query), flags)
+    hits: list[dict[str, Any]] = []
+    for p in iter_notes(base):
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            m = pat.search(line)
+            if not m:
+                continue
+            start = max(0, m.start() - snippet_chars // 2)
+            end = min(len(line), m.end() + snippet_chars // 2)
+            hits.append({
+                "path": str(p.relative_to(CFG.vault_root)),
+                "line": i,
+                "snippet": line[start:end],
+            })
+            if len(hits) >= limit:
+                return hits
+    return hits
+
+
+@mcp.tool()
+async def vault_metadata(path: str) -> dict[str, Any]:
+    """Read a note's frontmatter and stats without returning the body.
+    Useful for quick lookups."""
+    assert CFG is not None
+    target = safe_join(path)
+    if not target.is_file():
+        return {"error": f"not a file: {path}"}
+    stat = target.stat()
+    # Read just enough to capture the frontmatter block.
+    head = target.open("rb").read(8192).decode("utf-8", errors="replace")
+    fm, _ = parse_frontmatter(head)
+    return {
+        "path": str(target.relative_to(CFG.vault_root)),
+        "size": stat.st_size,
+        "mtime": stat.st_mtime,
+        "frontmatter": fm,
+    }
+
+
+# ── /health route (no auth) ──────────────────────────────────────────────────
+
+async def health(_request: Request) -> JSONResponse:
+    assert CFG is not None
+    vault_ok = CFG.vault_root.is_dir()
+    note_count = 0
+    try:
+        # Bound the count so a huge vault doesn't make the health check slow.
+        for _ in iter_notes():
+            note_count += 1
+            if note_count >= 1000:
+                break
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            {"status": "degraded", "vault_ok": False, "error": repr(e)}
+        )
+    return JSONResponse({
+        "status": "ok" if vault_ok else "degraded",
+        "vault_ok": vault_ok,
+        "vault_root": str(CFG.vault_root),
+        "approx_note_count": note_count if note_count < 1000 else f"{note_count}+",
+    })
+
+
+# ── lifespan + main ──────────────────────────────────────────────────────────
+
+@asynccontextmanager
+async def lifespan(_app: Starlette):
+    async with mcp.session_manager.run():
+        log.info("vault-mcp ready; vault_root=%s", CFG.vault_root if CFG else "?")
+        yield
+
+
+def build_app() -> Starlette:
+    mcp_app = mcp.streamable_http_app()
+    return Starlette(
+        debug=False,
+        routes=[
+            Route("/health", health, methods=["GET"]),
+            Mount("/", app=mcp_app),
+        ],
+        middleware=[Middleware(BearerAuthMiddleware)],
+        lifespan=lifespan,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("VAULT_MCP_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    global CFG, TOKENS_BY_HEX
+    CFG = Config()
+    TOKENS_BY_HEX = load_tokens(CFG.tokens_file)
+    bind_ip = CFG.resolve_bind_ip()
+    log.info(
+        "starting vault-mcp on %s:%d (vault=%s) with %d client tokens",
+        bind_ip, CFG.port, CFG.vault_root, len(TOKENS_BY_HEX),
+    )
+    uvicorn.run(build_app(), host=bind_ip, port=CFG.port, log_level="info")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -1,6 +1,7 @@
 alex_hash: ENC[AES256_GCM,data:wPEzo4HDQPBRKxmhZeDPsCs8QrhzPPaopSIqmXWPrmztZ5LQlg1elbYbEOWFS8hv20oJNPoP4VjBls8p/nIceXxmginXRwNj9Q==,iv:SZMa7wpGx0WjCQ28PCV11BZN6sCVRCzwI/Vjlwjor9o=,tag:H4SpMhLf0e82L+V6T4j0rQ==,type:str]
 tskey-reusable: ENC[AES256_GCM,data:3t9xz8MDnZg5mlxdyPKajqB6ldjFtErpw7U5oFzq46NTEiLdmUW0xweA9fTFHi0XseHlx65TfOYI7jSvpg==,iv:bvGRHcP+DFrqw9hzcXUhLLW9uZT6nLFFLI71MM4QGIg=,tag:klZhILl22ToJGtWOhDTjSg==,type:str]
 agent_memory_mcp_tokens: ENC[AES256_GCM,data:qPE6eNb3WAIdQZU/7MauS+izdEBX09UnYgxxrBzgN5Fs8+/Laa8YFdDRjbeZmvXOcYpZL0iFQ3DrkOoJLc5P3ifrtO2XCRe//PLYhYxMhV9BCdroIxOrUezf3GJZi41kmkkd/pqtlzthMuiBvh1o+7mXjO5FWk1TzoDru77Mu/DVd5G+6o+tmLGfEwrnqcs+nIg+4nRheU21D9O9tRqz56BseHzHRQoUgL//oh3NBcHDP7Fqs7KIwcikp2PrADl0WDosSi6rJJR/OTwi7mIl7tHv7lMxttQnQcdRrIHB0hJYGykZF6x8xFKxNzDd3kWyGIH0FmKG8pLAa9HyuUuYC1M84jXw,iv:ufITAD3JcGzPOLh5Nn/TPcx1ScvuSwwekunLiEgtpM8=,tag:t/OcOZtD1KGhLBYTGNzg3Q==,type:str]
+vault_mcp_tokens: ENC[AES256_GCM,data:ft7GY9b3LG8T2Ef9v+gqWIlaI0uLBgE0jIFAFrew+3dfMAaPOFraw5Nq/FILShOhHzgJLgfOVcSq7j9ZFB9m/I55e9zvusGXda3o/C6z8fUmYGdzWld3097v94DWxAm7ngXOg8jNcEJS2dA17dUrqbQ+xagebgdYON3WJIHfochlsljSshrdVm1K/cvepoUBbvK2qxWwBIOQldGwqPy0QljpcLwDzHpX2qT9ooi0qoBJlmzGjDI5FQBf//IrESX3JS9rVnXDWmwujsrpXQJhm3bkyAJV78hTt2ilzqhBdjTzpsBkyNraS0W9SS14Gxe4QHyfeDnVUb15lC0Nj4PIHCoc04BH,iv:g5GRZitrwPmJFmZk+DLB9kWqWRh0u5xtkF7Fya7GKQs=,tag:KBN5KPHf6QUcRAo7SATnSg==,type:str]
 sops:
     age:
         - recipient: age1udcr323x2wxg0ywcy3avq4q7gv9qvxrsuvpen6yve5zh9xaa3s0sfmxvcu
@@ -57,7 +58,7 @@ sops:
             TDBkVitzemVuRFl6TE1wZ0ZHVDNzT0UKmwnKv/hQFjYAOXJUPvvfRCGbU17tiVxL
             r/NSjG+se4lT6BKWrcjZcq0lwsrtKWHriA8ZhMECLW3SwDESzyn22g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-11T19:14:15Z"
-    mac: ENC[AES256_GCM,data:Z9vxOPgMW3WRut0uCJbcQj22XcndlJwp2HF58sPMZRmu9JKI1Or8DEQxBPIsq3AD+XzauOF49csHNR7JJZLkejCNw3PUUs2qd3M9b25EtIiGO4D58t8+bbxzWMIjLUMrn4tyHD/JfvHyY3ogesL5AzDlfztUfzahEzE4ClWR8NU=,iv:pIurWNtSVgdjMWbh23ID0bV2RQr/mGtWpMyiSrNPIo0=,tag:WmkrOmlkclHDC//uRqfAGg==,type:str]
+    lastmodified: "2026-05-11T20:24:29Z"
+    mac: ENC[AES256_GCM,data:FTKmeLSkrbDQFYIkXMGKKJPbTuORhEAsl5qCDNXTeKTjsjjxJycP/5QwBd/Ydudl1+mji2OSsH5zlYx8o7dUO+jh7WgLTmKTi9xQEABm7ptenKJE0yOCWDNjcV3tPlv/p9NatWd9o3mMjpidw9gc0hDbybZinRNhERDZqB8MRSk=,iv:yfIc120tcSXQjIqWCqqM9Mh4UMUDpK61pxFUrQWT6pc=,tag:gdz5K9+dJunSP4ri0DX9oA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
## Summary

- New `pkgs/obsidian-headless/` — `buildNpmPackage` for the Obsidian Sync headless daemon (proprietary UNLICENSED, allowed via the existing global `allowUnfree = true`). Node 22+, ships the `ob` binary. Better-sqlite3 native module builds in the nix sandbox.
- New `pkgs/vault-mcp/` — Python MCP server over an on-disk Obsidian vault. Tools: `vault_{read,write,append,list,search,metadata}`. Path safety: every path resolves under the vault root and rejects escapes, plus refuses `.obsidian/.trash/.git` regions.
- Two new NixOS modules under `roles/server/`:
  - `obsidian-headless/` — systemd service running `ob sync --continuous` as `alex` against `/home/alex/obsidian/Barrow-Downs`. Guarded by `ConditionPathExists` on the credential dir — service stays inactive until the user runs `ob login` once.
  - `vault-mcp/` — Tailnet-only (`:4281`), bearer-token auth via sops, runs as `alex`, points at the same vault path.
- `sops` adds `vault_mcp_tokens` (separate token map from `agent_memory_mcp_tokens`).
- Saruman config enables both modules.

The vault lives on its own btrfs subvol (`/home`, sda), naturally durable through reboots without needing impermanence rules.

## Test plan

- [x] `nix flake check` clean
- [x] `nix build` on `obsidian-headless`, `vault-mcp`, full saruman toplevel
- [x] Deployed to saruman via `colmena apply`
- [x] `vault-mcp.service` active; `/health` returns `{"status":"ok","vault_ok":true,"approx_note_count":"1000+"}`
- [x] `obsidian-headless.service` correctly inactive pending `ob login` (`ConditionPathExists` guard works)
- [x] `ob --version` returns `0.0.8` on PATH
- [x] Phase 1 (`agent-memory-mcp`) unaffected and still healthy
- [x] Immich + Paperless unaffected (shared PG15 cluster)
- [ ] User runs `ob login` once (manual, post-merge), service becomes active, vault stays in sync with Obsidian Sync

## Bootstrap reminder for the operator

```
ssh saruman
ob login            # interactive, email + password (no MFA)
systemctl status obsidian-headless   # should start after login
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)