### PR TITLE
Phase 3: Hermes Signal agent (NousResearch/hermes-agent + signal-cli)

### DIFF
--- a/AUTOMATION_ROADMAP.md
+++ b/AUTOMATION_ROADMAP.md
@@ -131,6 +131,18 @@ A persistent, semantic memory store on **saruman** that every agent (Claude acro
 - [ ] **Wired into Claude on both subscriptions** — work and personal Claude clients hit the same MCP endpoint; memories created by either are immediately visible to the other. Personal (faramir) verified; work subscription pending.
 - [ ] **Postgres major-version-bump safeguard** — surfaced during Phase 1 rollout: pinning `services.postgresql.package` to a different major than the host's existing data dir causes a silent `initdb` of a fresh empty cluster (data orphaned at the old version path). Document the `pg_upgrade` procedure or add a deploy preflight check.
 
+### B0.5: Hermes Signal Agent
+
+Reactive endpoint for the personal-agent stack: a Signal-driven agent that drives Claude (Anthropic native, swappable to OpenRouter for Nous Hermes models) and uses the shared `agent-memory` + `vault` MCP servers as tools. Adopts upstream `NousResearch/hermes-agent` (MIT, actively maintained; ships its own `flake.nix` + `nixosModules.default` and a uv2nix-sealed venv) rather than building from scratch.
+
+- [ ] **Upstream flake input** — `inputs.hermes-agent.url = "github:NousResearch/hermes-agent"`. Do not follow our nixpkgs; upstream's uv2nix lockfile is tied to nixos-unstable.
+- [ ] **`signal-cli` NixOS module** — local-only HTTP daemon at `127.0.0.1:8080`, runs as `hermes`, state persisted at `/var/lib/hermes/signal-cli`. Cannibalizes the retired ironclaw signal-cli unit.
+- [ ] **`hermes-agent` wiring module** — saruman-only (sets `services.hermes-agent.*` from the flake input). Provider `anthropic`, MCP servers `agent-memory` + `vault` wired to `:4280`/`:4281` with `future-hermes` bearer tokens via env-var interpolation; env file rendered from sops via `sops.templates."hermes-agent.env"`.
+- [ ] **sops scalars added** — `anthropic_api_key`, `hermes_bot_account`, `hermes_allowlist`, `future_hermes_agent_memory`, `future_hermes_vault`.
+- [ ] **Bootstrap** — `sudo -u hermes signal-cli link -n saruman-hermes` once; QR-scan from the bot's Signal account on the phone.
+- [ ] **Verified end-to-end** — allowlisted contact sends "ping" via Signal; reply within seconds. Tool use against memory + vault confirmed via natural language ("search my agent memory for X", "list my homelab folder").
+- [ ] **Spending alert** — Anthropic API usage alert set at console.anthropic.com (separate from any Claude subscription).
+
 ### B1: AI-Assisted Config Generation
 
 Use an LLM to generate NixOS module configs from natural language descriptions, reducing boilerplate and speeding up new service onboarding.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ _One Config to rule them all, One Config to find them; One Config to bring them 
 - [ ] Personal Agent Infrastructure
 	- [x] Phase 1: Shared agent memory on saruman (PostgreSQL + pgvector + MCP gateway, Tailscale-bound, bearer-token auth) ✅ 2026-05-11
 	- [ ] Phase 2: Obsidian Sync via `obsidian-headless` on saruman; vault MCP server(s) for read/write access
-	- [ ] Phase 3: Hermes agent on saruman driven by Anthropic API (later OpenRouter), Signal I/O via a dedicated number on signal-cli
+	- [ ] Phase 3: Hermes agent on saruman via upstream `NousResearch/hermes-agent`, Anthropic native now / OpenRouter for Nous Hermes later, Signal I/O via dedicated number on signal-cli
 	- [ ] Phase 4: Scheduled embedding/summarization jobs, task-capture workflows, web dashboard
 - [ ] Full Homelab Automation — Traditional Ops & AI-Augmented Ops (see [Automation Roadmap](AUTOMATION_ROADMAP.md))
 - [x] Disko configs for: ✅ 2024-03-01

--- a/flake.lock
+++ b/flake.lock
@@ -184,6 +184,27 @@
         "url": "https://flakehub.com/f/hercules-ci/flake-parts/0.1"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -263,6 +284,29 @@
         "owner": "nixos",
         "ref": "master",
         "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_3",
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1778535979,
+        "narHash": "sha256-PjXW4o90moh3MIYn4Dz4MsYf3LY5Kb5X68567yEIeHg=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "825bd50e6be1bfbde38d8337c599952da32b9a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
         "type": "github"
       }
     },
@@ -377,7 +421,7 @@
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "pre-commit-hooks": "pre-commit-hooks",
         "systems": "systems_2",
         "xdph": "xdph"
@@ -632,7 +676,7 @@
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1769548169,
@@ -768,6 +812,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1777954456,
         "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
@@ -782,7 +842,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1768564909,
         "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
@@ -798,7 +858,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1778003029,
         "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
@@ -812,7 +872,7 @@
         "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1775888245,
         "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
@@ -825,6 +885,27 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
         "type": "github"
       }
     },
@@ -851,24 +932,113 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769936401,
+        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "uv2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771518446,
+        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "claude-code": "claude-code",
         "determinate": "determinate",
         "disko": "disko",
         "hardware": "hardware",
+        "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "impermanence": "impermanence",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix"
       }
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1777944972,
@@ -911,6 +1081,55 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770770348,
+        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix_3"
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,11 @@
       url = "github:sadjow/claude-code-nix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    # Upstream agent runtime: ships its own flake + nixosModules.default and
+    # a uv2nix-built sealed venv. Do NOT set inputs.nixpkgs.follows here —
+    # the venv's lockfile is tied to nixos-unstable's Python toolchain;
+    # forcing it onto our nixpkgs (25.11) breaks the build.
+    hermes-agent.url = "github:NousResearch/hermes-agent";
   };
 
   outputs = { self, nixpkgs, home-manager, hardware, ... } @ inputs:
@@ -93,6 +98,7 @@
           modules = defaultModules ++ [
             hardware.nixosModules.common-gpu-nvidia-nonprime
             home-manager.nixosModules.home-manager
+            inputs.hermes-agent.nixosModules.default
             ./hosts/saruman/configuration.nix
             {
               home-manager.useUserPackages = true;

--- a/hosts/common/optional/roles/server/default.nix
+++ b/hosts/common/optional/roles/server/default.nix
@@ -29,5 +29,9 @@
     ./agent-memory
     ./obsidian-headless
     ./vault-mcp
+    ./signal-cli
+    # ./hermes-agent  — imported on saruman only (hosts/saruman/configuration.nix)
+    # because it sets services.hermes-agent.* which only exists where the
+    # upstream NousResearch/hermes-agent NixOS module is loaded.
   ];
 }

--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -1,0 +1,101 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.hermes-agent;
+  signalCfg = config.signal-cli;
+in
+{
+  options.hermes-agent = {
+    enable = lib.mkEnableOption "Hermes (NousResearch/hermes-agent) Signal bot wired to our MCP services";
+
+    model = lib.mkOption {
+      type = lib.types.str;
+      default = "anthropic/claude-opus-4.6";
+      description = ''
+        Model identifier for the agent's LLM. Default uses native Anthropic
+        provider; switch to e.g. "openrouter/nousresearch/hermes-3-llama-3.1-405b"
+        and add an OPENROUTER_API_KEY env var in the sops template to migrate.
+      '';
+    };
+
+    agentMemoryUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://${config.lab.hosts.saruman.ip}:4280/mcp";
+      description = "Streamable-HTTP URL for the agent-memory MCP server.";
+    };
+
+    vaultUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://${config.lab.hosts.saruman.ip}:4281/mcp";
+      description = "Streamable-HTTP URL for the vault MCP server.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Hermes is meaningless without the signal-cli HTTP daemon — turn it on.
+    signal-cli.enable = true;
+
+    # ─── sops scalars (values added via `sops secrets/main.yaml`) ───────────
+    sops.secrets = {
+      anthropic_api_key = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+      hermes_bot_account = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+      hermes_allowlist = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+      future_hermes_agent_memory = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+      future_hermes_vault = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+    };
+
+    # ─── EnvironmentFile rendered from sops at boot ────────────────────────
+    # Hermes reads every secret it needs from this single file. No plaintext
+    # ever lives in the Nix store.
+    sops.templates."hermes-agent.env" = {
+      owner = "hermes";
+      group = "hermes";
+      mode = "0400";
+      content = ''
+        ANTHROPIC_API_KEY=${config.sops.placeholder.anthropic_api_key}
+        SIGNAL_ACCOUNT=${config.sops.placeholder.hermes_bot_account}
+        SIGNAL_ALLOWED_USERS=${config.sops.placeholder.hermes_allowlist}
+        HERMES_AGENT_MEMORY_TOKEN=${config.sops.placeholder.future_hermes_agent_memory}
+        HERMES_VAULT_TOKEN=${config.sops.placeholder.future_hermes_vault}
+      '';
+    };
+
+    # ─── Upstream module configuration ─────────────────────────────────────
+    services.hermes-agent = {
+      enable = true;
+
+      environmentFiles = [ config.sops.templates."hermes-agent.env".path ];
+
+      environment = {
+        SIGNAL_HTTP_URL = "http://127.0.0.1:${toString signalCfg.httpPort}";
+        HERMES_HOME = "/var/lib/hermes/.hermes";
+      };
+
+      settings = {
+        model = {
+          provider = "anthropic";
+          default = cfg.model;
+          # api_key picked up from ANTHROPIC_API_KEY env var
+        };
+      };
+
+      mcpServers = {
+        agent-memory = {
+          url = cfg.agentMemoryUrl;
+          headers.Authorization = "Bearer \${HERMES_AGENT_MEMORY_TOKEN}";
+        };
+        vault = {
+          url = cfg.vaultUrl;
+          headers.Authorization = "Bearer \${HERMES_VAULT_TOKEN}";
+        };
+      };
+    };
+
+    # Guard: the hermes-agent service should not start until signal-cli has
+    # been linked. The upstream unit will retry on its own, but adding the
+    # explicit ordering keeps the journal cleaner.
+    systemd.services.hermes-agent = {
+      after = [ "signal-cli.service" ];
+      wants = [ "signal-cli.service" ];
+    };
+  };
+}

--- a/hosts/common/optional/roles/server/signal-cli/default.nix
+++ b/hosts/common/optional/roles/server/signal-cli/default.nix
@@ -1,0 +1,83 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.signal-cli;
+in
+{
+  options.signal-cli = {
+    enable = lib.mkEnableOption "signal-cli HTTP daemon for Hermes Signal bot";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hermes";
+      description = ''
+        UNIX user that owns signal-cli state and runs the daemon. Created
+        by the upstream hermes-agent NixOS module — we only depend on it
+        (and order ourselves before hermes-agent.service).
+      '';
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = ''
+        Local port the signal-cli HTTP daemon listens on. Loopback only;
+        never opened in the firewall. Hermes connects via 127.0.0.1.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/hermes/signal-cli";
+      description = ''
+        Where signal-cli stores its linked-device key state, contacts,
+        sessions, and message cache. Persisted under /persist via
+        impermanence so the link survives reboots.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.signal-cli ];
+
+    # Persist the entire signal-cli state dir across reboots — losing it
+    # would mean re-linking the device.
+    environment.persistence."/persist".directories = [
+      { directory = cfg.dataDir; user = cfg.user; group = cfg.user; mode = "0700"; }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.user} -"
+    ];
+
+    systemd.services.signal-cli = {
+      description = "signal-cli HTTP daemon (Signal protocol gateway for Hermes)";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      before = [ "hermes-agent.service" ];
+
+      environment = {
+        # signal-cli respects XDG_DATA_HOME for its state dir. Point it at
+        # our persisted location.
+        XDG_DATA_HOME = builtins.toString (builtins.dirOf cfg.dataDir);
+      };
+
+      serviceConfig = {
+        ExecStart = "${pkgs.signal-cli}/bin/signal-cli daemon --http=127.0.0.1:${toString cfg.httpPort}";
+        User = cfg.user;
+        Group = cfg.user;
+        Restart = "always";
+        RestartSec = "5s";
+
+        # Hardening; service needs read+write on its data dir only.
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ReadWritePaths = [ cfg.dataDir ];
+      };
+    };
+
+    # No firewall opening: loopback-only by design.
+  };
+}

--- a/hosts/saruman/configuration.nix
+++ b/hosts/saruman/configuration.nix
@@ -5,6 +5,9 @@
       ../common/global
       ../common/optional
       ../common/optional/roles/server
+      ../common/optional/roles/server/hermes-agent  # saruman-only — depends on
+                                                    # upstream services.hermes-agent
+                                                    # option from the flake input
       ../common/optional/roles/workstation
       ../../disko/saruman.nix
     ];
@@ -29,6 +32,7 @@
   agent-memory.enable = true;
   obsidian-headless.enable = true;
   vault-mcp.enable = true;
+  hermes-agent.enable = true;  # transitively enables signal-cli
 
 
   boot.loader.systemd-boot.enable = true;

--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -2,6 +2,11 @@ alex_hash: ENC[AES256_GCM,data:wPEzo4HDQPBRKxmhZeDPsCs8QrhzPPaopSIqmXWPrmztZ5LQl
 tskey-reusable: ENC[AES256_GCM,data:3t9xz8MDnZg5mlxdyPKajqB6ldjFtErpw7U5oFzq46NTEiLdmUW0xweA9fTFHi0XseHlx65TfOYI7jSvpg==,iv:bvGRHcP+DFrqw9hzcXUhLLW9uZT6nLFFLI71MM4QGIg=,tag:klZhILl22ToJGtWOhDTjSg==,type:str]
 agent_memory_mcp_tokens: ENC[AES256_GCM,data:qPE6eNb3WAIdQZU/7MauS+izdEBX09UnYgxxrBzgN5Fs8+/Laa8YFdDRjbeZmvXOcYpZL0iFQ3DrkOoJLc5P3ifrtO2XCRe//PLYhYxMhV9BCdroIxOrUezf3GJZi41kmkkd/pqtlzthMuiBvh1o+7mXjO5FWk1TzoDru77Mu/DVd5G+6o+tmLGfEwrnqcs+nIg+4nRheU21D9O9tRqz56BseHzHRQoUgL//oh3NBcHDP7Fqs7KIwcikp2PrADl0WDosSi6rJJR/OTwi7mIl7tHv7lMxttQnQcdRrIHB0hJYGykZF6x8xFKxNzDd3kWyGIH0FmKG8pLAa9HyuUuYC1M84jXw,iv:ufITAD3JcGzPOLh5Nn/TPcx1ScvuSwwekunLiEgtpM8=,tag:t/OcOZtD1KGhLBYTGNzg3Q==,type:str]
 vault_mcp_tokens: ENC[AES256_GCM,data:ft7GY9b3LG8T2Ef9v+gqWIlaI0uLBgE0jIFAFrew+3dfMAaPOFraw5Nq/FILShOhHzgJLgfOVcSq7j9ZFB9m/I55e9zvusGXda3o/C6z8fUmYGdzWld3097v94DWxAm7ngXOg8jNcEJS2dA17dUrqbQ+xagebgdYON3WJIHfochlsljSshrdVm1K/cvepoUBbvK2qxWwBIOQldGwqPy0QljpcLwDzHpX2qT9ooi0qoBJlmzGjDI5FQBf//IrESX3JS9rVnXDWmwujsrpXQJhm3bkyAJV78hTt2ilzqhBdjTzpsBkyNraS0W9SS14Gxe4QHyfeDnVUb15lC0Nj4PIHCoc04BH,iv:g5GRZitrwPmJFmZk+DLB9kWqWRh0u5xtkF7Fya7GKQs=,tag:KBN5KPHf6QUcRAo7SATnSg==,type:str]
+anthropic_api_key: ENC[AES256_GCM,data:rlOoVIBUJKy8ZOkJ0puzwnkFEXxkibBKwB8XW8x8D8KfOsXHtKETjjU6ojqAh44rXxAgOJULSc1mA4uN5sFca7KFsImxrzQT2b7EXguWZgoOyg5lxfA3YUS1KzWC0Ghh7JDW2KDCFZ8zutpP,iv:mxOh7v35fa1j++IoyequkESox6CRgXqQlXjYtkjQcng=,tag:bZzSNtmVBCxPEyWwkyhrLA==,type:str]
+hermes_bot_account: ENC[AES256_GCM,data:SnXgC/xbrNd9heNK,iv:2+Wzj5jsvVgIw7JaMAhXVPGGAi5VMBLoiBiDyQljT0U=,tag:rqjzWS6YaH7Uygjy3hNM8w==,type:str]
+hermes_allowlist: ENC[AES256_GCM,data:VKh5S0G0wZBfjRAQ,iv:tyevrQ6niQUpIquSDsR55+8gTAnNnm7oAixTXiNCAgo=,tag:6SWPeSufpknVICpEEx5zcw==,type:str]
+future_hermes_agent_memory: ENC[AES256_GCM,data:8C7g2R6ty6G8Lczy5LeOqmdYzZfLx+h7rqo7xaaDZGU63OaulwXz0M6C3zGtLHFcPBE1T3ReBvqdFLlNU0SdCw==,iv:1lc6Csx5aHjs5UxEEsBe/JONDbI+JsUdQiJYKn02LZ0=,tag:9nwMlJXvh36bLRyypH26ng==,type:str]
+future_hermes_vault: ENC[AES256_GCM,data:gfG9PUlIozA8sag8jnInc+d42pD4JXxpHkQ4VFJ+fbnWGHYNlmUX3eAsYYrLp5uGXkTwprMFdXgRoZ60b7otTw==,iv:RDjv7AIHj7WsqwpXxVUIpqEEFlEVyXgajgAYfKA59EI=,tag:JxzCvGYStWKyfElSGEMd5Q==,type:str]
 sops:
     age:
         - recipient: age1udcr323x2wxg0ywcy3avq4q7gv9qvxrsuvpen6yve5zh9xaa3s0sfmxvcu
@@ -58,7 +63,7 @@ sops:
             TDBkVitzemVuRFl6TE1wZ0ZHVDNzT0UKmwnKv/hQFjYAOXJUPvvfRCGbU17tiVxL
             r/NSjG+se4lT6BKWrcjZcq0lwsrtKWHriA8ZhMECLW3SwDESzyn22g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-11T20:24:29Z"
-    mac: ENC[AES256_GCM,data:FTKmeLSkrbDQFYIkXMGKKJPbTuORhEAsl5qCDNXTeKTjsjjxJycP/5QwBd/Ydudl1+mji2OSsH5zlYx8o7dUO+jh7WgLTmKTi9xQEABm7ptenKJE0yOCWDNjcV3tPlv/p9NatWd9o3mMjpidw9gc0hDbybZinRNhERDZqB8MRSk=,iv:yfIc120tcSXQjIqWCqqM9Mh4UMUDpK61pxFUrQWT6pc=,tag:gdz5K9+dJunSP4ri0DX9oA==,type:str]
+    lastmodified: "2026-05-11T21:46:57Z"
+    mac: ENC[AES256_GCM,data:rDHrGgleGhURnePZEwkCXPyOGAFkgZ6afchBBNSa46jzwp5ZhLLbizI/K3GXebHSD4o9dEo60nBfaz5I/eKuU8rkRpWjXlxlyRbDCeoA3Q1EwpHG+LWwMYm2wYXMNrpj/3ox8IVplMvnb5aM3mY0NOkMTH/9VnYbILom8r5ufTs=,iv:R/VR3LtyslrbFy/NbdcvCaRu0rRCSDdjH3uKf6fBRTw=,tag:NTJGM8Tg1k6qKcShOcH/aQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
## Summary

- New flake input `hermes-agent.url = "github:NousResearch/hermes-agent"`. Upstream is MIT-licensed, actively maintained, ships its own `flake.nix` + `nixosModules.default` and a uv2nix-sealed venv. Imported into saruman's modules list.
- New `signal-cli` NixOS module (`hosts/common/optional/roles/server/signal-cli/`) — loopback HTTP daemon at `127.0.0.1:8080`, runs as `hermes` system user, state persisted at `/var/lib/hermes/signal-cli` via impermanence. Cannibalizes the retired ironclaw signal-cli systemd unit.
- New `hermes-agent` wiring module (`hosts/common/optional/roles/server/hermes-agent/`). **Saruman-only import** (not via `roles/server/default.nix`) because it sets `services.hermes-agent.*`, which only exists where the upstream flake input is loaded. Configures Anthropic native LLM, wires `agent-memory` (`:4280`) + `vault` (`:4281`) MCP servers via StreamableHTTP with `future-hermes` bearer tokens via env-var interpolation, points the upstream `environmentFiles` at a sops template rendered at boot.
- Five new sops scalars: `anthropic_api_key`, `hermes_bot_account`, `hermes_allowlist`, `future_hermes_agent_memory`, `future_hermes_vault`. The original `agent_memory_mcp_tokens` + `vault_mcp_tokens` JSON maps are untouched.
- README + AUTOMATION_ROADMAP B0.5 entries.

## Test plan

- [x] `nix flake check --no-build` clean across all hosts
- [x] `nix build .#nixosConfigurations.saruman.config.system.build.toplevel` succeeds (upstream uv2nix venv builds clean)
- [ ] `colmena apply --on saruman` deploys cleanly
- [ ] `signal-cli` daemon active, binds loopback only
- [ ] `sudo -u hermes signal-cli link -n saruman-hermes` interactive bootstrap; QR scanned from bot's Signal account
- [ ] `hermes-agent` service transitions to active after signal-cli is linked
- [ ] Journal shows MCP servers connected (`agent-memory` + `vault` tools loaded)
- [ ] Allowlisted contact "ping" → text reply within seconds
- [ ] Tool use: "search my agent memory for X" calls `memory_search`
- [ ] Tool use: "list my 08 - homelab folder" calls `vault_list`
- [ ] Multi-turn coherence verified
- [ ] Non-allowlisted sender silently ignored (logged)
- [ ] Auto-deploy compatibility on next hourly tick

## Bootstrap (manual, post-deploy)

```
sudo -u hermes signal-cli link -n "saruman-hermes"
# scan QR from bot's Signal app: Settings → Linked Devices → "+"
sudo -u hermes signal-cli listAccounts
sudo systemctl status hermes-agent
journalctl -u hermes-agent -f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)