### PR TITLE
chore: signal-cli on 8088 (open-webui owns 8080)

### DIFF
--- a/hosts/common/optional/roles/server/signal-cli/default.nix
+++ b/hosts/common/optional/roles/server/signal-cli/default.nix
@@ -18,10 +18,11 @@ in
 
     httpPort = lib.mkOption {
       type = lib.types.port;
-      default = 8080;
+      default = 8088;
       description = ''
         Local port the signal-cli HTTP daemon listens on. Loopback only;
         never opened in the firewall. Hermes connects via 127.0.0.1.
+        Default 8088 (not 8080) — open-webui already binds 8080 on saruman.
       '';
     };
 


### PR DESCRIPTION
Move `signal-cli.httpPort` default from 8080 to 8088. open-webui on saruman already binds 8080; signal-cli was failing to start on Phase 3 deploy. 8088 is the port retired ironclaw used. Hermes follows automatically via signalCfg.httpPort.