### PR TITLE
chore(hermes): allowlist accepts UUID in addition to E.164

### DIFF
--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -4,7 +4,7 @@ agent_memory_mcp_tokens: ENC[AES256_GCM,data:qPE6eNb3WAIdQZU/7MauS+izdEBX09UnYgx
 vault_mcp_tokens: ENC[AES256_GCM,data:ft7GY9b3LG8T2Ef9v+gqWIlaI0uLBgE0jIFAFrew+3dfMAaPOFraw5Nq/FILShOhHzgJLgfOVcSq7j9ZFB9m/I55e9zvusGXda3o/C6z8fUmYGdzWld3097v94DWxAm7ngXOg8jNcEJS2dA17dUrqbQ+xagebgdYON3WJIHfochlsljSshrdVm1K/cvepoUBbvK2qxWwBIOQldGwqPy0QljpcLwDzHpX2qT9ooi0qoBJlmzGjDI5FQBf//IrESX3JS9rVnXDWmwujsrpXQJhm3bkyAJV78hTt2ilzqhBdjTzpsBkyNraS0W9SS14Gxe4QHyfeDnVUb15lC0Nj4PIHCoc04BH,iv:g5GRZitrwPmJFmZk+DLB9kWqWRh0u5xtkF7Fya7GKQs=,tag:KBN5KPHf6QUcRAo7SATnSg==,type:str]
 anthropic_api_key: ENC[AES256_GCM,data:rlOoVIBUJKy8ZOkJ0puzwnkFEXxkibBKwB8XW8x8D8KfOsXHtKETjjU6ojqAh44rXxAgOJULSc1mA4uN5sFca7KFsImxrzQT2b7EXguWZgoOyg5lxfA3YUS1KzWC0Ghh7JDW2KDCFZ8zutpP,iv:mxOh7v35fa1j++IoyequkESox6CRgXqQlXjYtkjQcng=,tag:bZzSNtmVBCxPEyWwkyhrLA==,type:str]
 hermes_bot_account: ENC[AES256_GCM,data:SnXgC/xbrNd9heNK,iv:2+Wzj5jsvVgIw7JaMAhXVPGGAi5VMBLoiBiDyQljT0U=,tag:rqjzWS6YaH7Uygjy3hNM8w==,type:str]
-hermes_allowlist: ENC[AES256_GCM,data:VKh5S0G0wZBfjRAQ,iv:tyevrQ6niQUpIquSDsR55+8gTAnNnm7oAixTXiNCAgo=,tag:6SWPeSufpknVICpEEx5zcw==,type:str]
+hermes_allowlist: ENC[AES256_GCM,data:LE92/yD8EzsfRa92jQqq1xf3F9GAjs4J3Z/ju4nwfimYoL1vN5cgUmEdzQKe+KX+tQ==,iv:8LqFFVeR8oMstCzDx+zD8atYM/L8O3EcRrM90NH9q6c=,tag:KykHC1O4L2WDFyiNgVSw9g==,type:str]
 future_hermes_agent_memory: ENC[AES256_GCM,data:8C7g2R6ty6G8Lczy5LeOqmdYzZfLx+h7rqo7xaaDZGU63OaulwXz0M6C3zGtLHFcPBE1T3ReBvqdFLlNU0SdCw==,iv:1lc6Csx5aHjs5UxEEsBe/JONDbI+JsUdQiJYKn02LZ0=,tag:9nwMlJXvh36bLRyypH26ng==,type:str]
 future_hermes_vault: ENC[AES256_GCM,data:gfG9PUlIozA8sag8jnInc+d42pD4JXxpHkQ4VFJ+fbnWGHYNlmUX3eAsYYrLp5uGXkTwprMFdXgRoZ60b7otTw==,iv:RDjv7AIHj7WsqwpXxVUIpqEEFlEVyXgajgAYfKA59EI=,tag:JxzCvGYStWKyfElSGEMd5Q==,type:str]
 sops:
@@ -63,7 +63,7 @@ sops:
             TDBkVitzemVuRFl6TE1wZ0ZHVDNzT0UKmwnKv/hQFjYAOXJUPvvfRCGbU17tiVxL
             r/NSjG+se4lT6BKWrcjZcq0lwsrtKWHriA8ZhMECLW3SwDESzyn22g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-11T21:46:57Z"
-    mac: ENC[AES256_GCM,data:rDHrGgleGhURnePZEwkCXPyOGAFkgZ6afchBBNSa46jzwp5ZhLLbizI/K3GXebHSD4o9dEo60nBfaz5I/eKuU8rkRpWjXlxlyRbDCeoA3Q1EwpHG+LWwMYm2wYXMNrpj/3ox8IVplMvnb5aM3mY0NOkMTH/9VnYbILom8r5ufTs=,iv:R/VR3LtyslrbFy/NbdcvCaRu0rRCSDdjH3uKf6fBRTw=,tag:NTJGM8Tg1k6qKcShOcH/aQ==,type:str]
+    lastmodified: "2026-05-11T22:55:07Z"
+    mac: ENC[AES256_GCM,data:sh9Cd4wOK7xLL6m3pDG2vJINGJLrwZh2RaqgAUvy83yg1/RpiGWKm9OoUxuA5BDjnzpVc6Kyk3ftFPtxh6DRAQF0RyVz+yoYIArihixPnHstE5No4M/H8HW8r8cfHvwi5ALa6T9jB6hFJoagEcAI6XGfgJg0parY9edhP6sRyPo=,iv:32RGgyjn0GMkEyp2Tp8ZTNSDMdcILMAKYLydEoOmPCU=,tag:32CR4D/U+7c7JQ812vZHnA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
Signal identifies users by ACI UUID — the allowlist check was rejecting valid messages with "Unauthorized user". Add the UUID alongside the E.164 in `hermes_allowlist` sops secret. (Secret-only change; no Nix file diff, just the encrypted yaml.)