### PR TITLE
chore(hermes/signal-cli): polish — explicit --config dataDir + wider TimeoutStopSec

### DIFF
--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -97,10 +97,14 @@ in
 
     # Guard: the hermes-agent service should not start until signal-cli has
     # been linked. The upstream unit will retry on its own, but adding the
-    # explicit ordering keeps the journal cleaner.
+    # explicit ordering keeps the journal cleaner. Also widen the stop
+    # timeout — upstream emits a runtime warning if TimeoutStopSec < 210s
+    # because the agent's in-flight drain can take up to 180s; the NixOS
+    # module ships 90s by default which trips that warning every boot.
     systemd.services.hermes-agent = {
       after = [ "signal-cli.service" ];
       wants = [ "signal-cli.service" ];
+      serviceConfig.TimeoutStopSec = 240;
     };
   };
 }

--- a/hosts/common/optional/roles/server/signal-cli/default.nix
+++ b/hosts/common/optional/roles/server/signal-cli/default.nix
@@ -1,6 +1,14 @@
 { lib, pkgs, config, ... }:
 let
   cfg = config.signal-cli;
+  # Wrapper that locks in the same data directory the daemon uses.
+  # Without this, ad-hoc `sudo -u hermes signal-cli ...` invocations fall back
+  # to the user-default `~/.local/share/signal-cli/`, which diverges from the
+  # daemon's path and means newly-registered accounts don't show up over the
+  # HTTP RPC. The wrapper makes the operator command path-agnostic.
+  signal-cli-hermes = pkgs.writeShellScriptBin "signal-cli-hermes" ''
+    exec ${pkgs.signal-cli}/bin/signal-cli --config ${cfg.dataDir} "$@"
+  '';
 in
 {
   options.signal-cli = {
@@ -38,7 +46,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.signal-cli ];
+    environment.systemPackages = [ pkgs.signal-cli signal-cli-hermes ];
 
     # Persist the entire signal-cli state dir across reboots — losing it
     # would mean re-linking the device.
@@ -57,14 +65,14 @@ in
       wantedBy = [ "multi-user.target" ];
       before = [ "hermes-agent.service" ];
 
-      environment = {
-        # signal-cli respects XDG_DATA_HOME for its state dir. Point it at
-        # our persisted location.
-        XDG_DATA_HOME = builtins.toString (builtins.dirOf cfg.dataDir);
-      };
+      # Data dir is set explicitly via `--config` rather than XDG_DATA_HOME.
+      # This means operators using `signal-cli` directly (without our wrapper)
+      # won't accidentally write account state to ~/.local/share/signal-cli/
+      # and surprise the daemon. Use the `signal-cli-hermes` wrapper on PATH
+      # for any interactive admin commands.
 
       serviceConfig = {
-        ExecStart = "${pkgs.signal-cli}/bin/signal-cli daemon --http=127.0.0.1:${toString cfg.httpPort}";
+        ExecStart = "${pkgs.signal-cli}/bin/signal-cli --config ${cfg.dataDir} daemon --http=127.0.0.1:${toString cfg.httpPort}";
         User = cfg.user;
         Group = cfg.user;
         Restart = "always";


### PR DESCRIPTION
Two follow-ups from Phase 3 deploy:

1. **signal-cli**: drop `XDG_DATA_HOME` env hack in favor of an explicit `--config <dataDir>` flag on the daemon ExecStart, plus a `signal-cli-hermes` wrapper script in systemPackages. Removes the operator-vs-daemon path divergence that bit us during the register bootstrap.
2. **hermes-agent**: override `serviceConfig.TimeoutStopSec = 240` to silence the upstream "TimeoutStopSec < 210s" warning.

Note: the `MESSAGING_CWD .env deprecation` warning originates from the upstream hermes-agent NixOS module's `workingDirectory` option — fixing that requires an upstream PR. Tracked in our AUTOMATION_ROADMAP.