### PR TITLE
Add miniflux-mcp (RSS reader MCP)

### DIFF
--- a/hosts/common/optional/roles/server/default.nix
+++ b/hosts/common/optional/roles/server/default.nix
@@ -32,6 +32,7 @@
     ./signal-cli
     ./signal-mcp
     ./radicale-mcp
+    ./miniflux-mcp
     # ./hermes-agent  — imported on saruman only (hosts/saruman/configuration.nix)
     # because it sets services.hermes-agent.* which only exists where the
     # upstream NousResearch/hermes-agent NixOS module is loaded.

--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -45,6 +45,12 @@ in
       default = "http://100.104.242.112:4283/mcp";
       description = "Streamable-HTTP URL for the Radicale CalDAV/CardDAV MCP.";
     };
+
+    minifluxMcpUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://100.104.242.112:4284/mcp";
+      description = "Streamable-HTTP URL for the Miniflux RSS MCP.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -60,6 +66,7 @@ in
       future_hermes_vault = { owner = "hermes"; group = "hermes"; mode = "0400"; };
       future_hermes_signal = { owner = "hermes"; group = "hermes"; mode = "0400"; };
       future_hermes_radicale = { owner = "hermes"; group = "hermes"; mode = "0400"; };
+      future_hermes_miniflux = { owner = "hermes"; group = "hermes"; mode = "0400"; };
     };
 
     # ─── EnvironmentFile rendered from sops at boot ────────────────────────
@@ -77,6 +84,7 @@ in
         HERMES_VAULT_TOKEN=${config.sops.placeholder.future_hermes_vault}
         HERMES_SIGNAL_MCP_TOKEN=${config.sops.placeholder.future_hermes_signal}
         HERMES_RADICALE_MCP_TOKEN=${config.sops.placeholder.future_hermes_radicale}
+        HERMES_MINIFLUX_MCP_TOKEN=${config.sops.placeholder.future_hermes_miniflux}
       '';
     };
 
@@ -115,6 +123,10 @@ in
         radicale = {
           url = cfg.radicaleMcpUrl;
           headers.Authorization = "Bearer \${HERMES_RADICALE_MCP_TOKEN}";
+        };
+        miniflux = {
+          url = cfg.minifluxMcpUrl;
+          headers.Authorization = "Bearer \${HERMES_MINIFLUX_MCP_TOKEN}";
         };
       };
     };

--- a/hosts/common/optional/roles/server/miniflux-mcp/default.nix
+++ b/hosts/common/optional/roles/server/miniflux-mcp/default.nix
@@ -1,0 +1,116 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.miniflux-mcp;
+  hosts = config.lab.hosts;
+in
+{
+  options.miniflux-mcp = {
+    enable = lib.mkEnableOption "Miniflux RSS reader MCP gateway";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4284;
+      description = "TCP port the miniflux-mcp gateway listens on. Tailnet IP only.";
+    };
+
+    bindIp = lib.mkOption {
+      type = lib.types.str;
+      default = "auto";
+      description = "IPv4 to bind. \"auto\" resolves tailnet IP at service start.";
+    };
+
+    tailnetInterface = lib.mkOption {
+      type = lib.types.str;
+      default = "tailscale0";
+      description = "Interface on which to open the MCP port in the firewall.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "miniflux_mcp";
+      description = "System user to run the service as.";
+    };
+
+    minifluxUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://${hosts.phantom.ip}:8080";
+      description = ''
+        Base URL of the Miniflux instance (no trailing /v1). Defaults to the
+        phantom-hosted instance on the LAN (also reachable via tailnet).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.user;
+      home = "/var/lib/miniflux-mcp";
+      createHome = true;
+      description = "miniflux-mcp service user";
+    };
+    users.groups.${cfg.user} = { };
+
+    sops.secrets.miniflux_mcp_tokens = {
+      owner = cfg.user;
+      group = cfg.user;
+      mode = "0400";
+    };
+    sops.secrets.miniflux_api_token = {
+      owner = cfg.user;
+      group = cfg.user;
+      mode = "0400";
+    };
+
+    # Render an EnvironmentFile with just the upstream Miniflux API token.
+    # Pattern mirrors radicale-mcp.env / signal-mcp.env from earlier modules.
+    sops.templates."miniflux-mcp.env" = {
+      owner = cfg.user;
+      group = cfg.user;
+      mode = "0400";
+      content = ''
+        MINIFLUX_MCP_MINIFLUX_TOKEN=${config.sops.placeholder.miniflux_api_token}
+      '';
+    };
+
+    environment.persistence."/persist".directories = [
+      { directory = "/var/lib/miniflux-mcp"; user = cfg.user; group = cfg.user; mode = "0750"; }
+    ];
+    systemd.tmpfiles.rules = [
+      "d /var/lib/miniflux-mcp 0750 ${cfg.user} ${cfg.user} -"
+    ];
+
+    systemd.services.miniflux-mcp = {
+      description = "Miniflux RSS reader MCP gateway";
+      after = [ "network-online.target" "tailscaled.service" ];
+      wants = [ "network-online.target" "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ config.services.tailscale.package ];
+
+      environment = {
+        MINIFLUX_MCP_BIND_IP = cfg.bindIp;
+        MINIFLUX_MCP_PORT = toString cfg.port;
+        MINIFLUX_MCP_TOKENS_FILE = config.sops.secrets.miniflux_mcp_tokens.path;
+        MINIFLUX_MCP_MINIFLUX_URL = cfg.minifluxUrl;
+      };
+
+      serviceConfig = {
+        ExecStart = "${pkgs.miniflux-mcp}/bin/miniflux-mcp";
+        EnvironmentFile = config.sops.templates."miniflux-mcp.env".path;
+        User = cfg.user;
+        Group = cfg.user;
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ReadWritePaths = [ "/var/lib/miniflux-mcp" ];
+      };
+    };
+
+    networking.firewall.interfaces.${cfg.tailnetInterface}.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/hosts/saruman/configuration.nix
+++ b/hosts/saruman/configuration.nix
@@ -35,6 +35,7 @@
   hermes-agent.enable = true;  # transitively enables signal-cli
   signal-mcp.enable = true;    # outbound Signal MCP with approval gate
   radicale-mcp.enable = true;  # CalDAV/CardDAV MCP (talks to phantom's Radicale)
+  miniflux-mcp.enable = true;  # Miniflux RSS reader MCP (talks to phantom's Miniflux)
 
 
   boot.loader.systemd-boot.enable = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,4 +6,5 @@
   vault-mcp = pkgs.callPackage ./vault-mcp { python3 = pkgs.python3; };
   signal-mcp = pkgs.callPackage ./signal-mcp { python3 = pkgs.python3; };
   radicale-mcp = pkgs.callPackage ./radicale-mcp { python3 = pkgs.python3; };
+  miniflux-mcp = pkgs.callPackage ./miniflux-mcp { python3 = pkgs.python3; };
 }

--- a/pkgs/miniflux-mcp/default.nix
+++ b/pkgs/miniflux-mcp/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "miniflux-mcp";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  dependencies = with python3.pkgs; [
+    mcp
+    starlette
+    uvicorn
+    httpx
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "MCP server fronting a Miniflux RSS reader instance";
+    license = licenses.mit;
+    mainProgram = "miniflux-mcp";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/miniflux-mcp/miniflux_mcp/server.py
+++ b/pkgs/miniflux-mcp/miniflux_mcp/server.py
@@ -1,0 +1,264 @@
+"""Miniflux MCP server.
+
+Thin MCP wrapper over the Miniflux REST API (v1). Auth: bearer token at
+the MCP layer (sops-managed). The MCP-to-Miniflux auth uses an X-Auth-Token
+header (Miniflux's own personal API key, also from sops).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+log = logging.getLogger("miniflux_mcp")
+
+
+class Config:
+    def __init__(self) -> None:
+        self.bind_ip = os.environ.get("MINIFLUX_MCP_BIND_IP", "auto")
+        self.port = int(os.environ.get("MINIFLUX_MCP_PORT", "4284"))
+        self.tokens_file = os.environ["MINIFLUX_MCP_TOKENS_FILE"]
+        self.miniflux_url = os.environ["MINIFLUX_MCP_MINIFLUX_URL"].rstrip("/")
+        self.miniflux_token = os.environ["MINIFLUX_MCP_MINIFLUX_TOKEN"]
+
+    def resolve_bind_ip(self) -> str:
+        if self.bind_ip != "auto":
+            return self.bind_ip
+        r = subprocess.run(
+            ["tailscale", "ip", "-4"], capture_output=True, text=True, check=True
+        )
+        return r.stdout.strip().splitlines()[0]
+
+
+def load_tokens(path: str) -> dict[str, str]:
+    with open(path) as f:
+        raw = json.load(f)
+    tokens = raw.get("tokens", raw)
+    if not isinstance(tokens, dict) or not tokens:
+        raise SystemExit(f"{path}: expected non-empty token map")
+    return {tok: client for client, tok in tokens.items()}
+
+
+CFG: Config | None = None
+TOKENS_BY_HEX: dict[str, str] = {}
+
+
+# ── auth middleware ─────────────────────────────────────────────────────────
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        if not auth.lower().startswith("bearer "):
+            return JSONResponse({"error": "missing bearer token"}, status_code=401)
+        token = auth.split(" ", 1)[1].strip()
+        client = TOKENS_BY_HEX.get(token)
+        if client is None:
+            return JSONResponse({"error": "invalid token"}, status_code=401)
+        request.state.client = client
+        return await call_next(request)
+
+
+# ── miniflux API client ─────────────────────────────────────────────────────
+
+async def miniflux(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_body: Any = None,
+) -> Any:
+    """Call the Miniflux REST API. Path is relative to /v1/."""
+    assert CFG is not None
+    url = f"{CFG.miniflux_url}/v1/{path.lstrip('/')}"
+    headers = {"X-Auth-Token": CFG.miniflux_token}
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        r = await client.request(method, url, headers=headers, params=params, json=json_body)
+    if r.status_code >= 400:
+        # Surface a structured error to the caller, but never the auth token.
+        raise RuntimeError(f"miniflux {method} {path} -> {r.status_code}: {r.text[:500]}")
+    if not r.content:
+        return None
+    return r.json()
+
+
+# ── MCP server ──────────────────────────────────────────────────────────────
+
+mcp = FastMCP("miniflux")
+
+
+@mcp.tool()
+async def me() -> dict[str, Any]:
+    """Return the current Miniflux user (whoever owns the configured API key)."""
+    return await miniflux("GET", "/me")
+
+
+@mcp.tool()
+async def feed_list(category_id: int | None = None) -> list[dict[str, Any]]:
+    """List subscribed feeds. Optionally filter to a specific category."""
+    if category_id is not None:
+        return await miniflux("GET", f"/categories/{category_id}/feeds")
+    return await miniflux("GET", "/feeds")
+
+
+@mcp.tool()
+async def feed_get(feed_id: int) -> dict[str, Any]:
+    """Get a single feed by id."""
+    return await miniflux("GET", f"/feeds/{feed_id}")
+
+
+@mcp.tool()
+async def category_list() -> list[dict[str, Any]]:
+    """List all feed categories on the account."""
+    return await miniflux("GET", "/categories")
+
+
+@mcp.tool()
+async def entry_list(
+    status: str | None = None,
+    feed_id: int | None = None,
+    category_id: int | None = None,
+    search: str | None = None,
+    starred: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    order: str = "published_at",
+    direction: str = "desc",
+) -> dict[str, Any]:
+    """List entries. By default returns the 50 most recent across all feeds.
+
+    Filters (combinable):
+    - `status`: 'unread' | 'read' | 'removed'
+    - `feed_id`: restrict to one feed
+    - `category_id`: restrict to one category
+    - `search`: substring search across title + content
+    - `starred`: True to include only starred entries
+    Returns `{total, entries: [...]}`. Each entry has id, title, url,
+    published_at, content (HTML), feed, status, starred.
+    """
+    params: dict[str, Any] = {"limit": limit, "offset": offset, "order": order, "direction": direction}
+    if status is not None:
+        params["status"] = status
+    if search is not None:
+        params["search"] = search
+    if starred is not None:
+        params["starred"] = "true" if starred else "false"
+    if feed_id is not None:
+        return await miniflux("GET", f"/feeds/{feed_id}/entries", params=params)
+    if category_id is not None:
+        return await miniflux("GET", f"/categories/{category_id}/entries", params=params)
+    return await miniflux("GET", "/entries", params=params)
+
+
+@mcp.tool()
+async def entry_get(entry_id: int) -> dict[str, Any]:
+    """Fetch a single entry by id, with full content."""
+    return await miniflux("GET", f"/entries/{entry_id}")
+
+
+@mcp.tool()
+async def entry_mark_read(entry_ids: list[int]) -> dict[str, Any]:
+    """Mark one or more entries as read."""
+    await miniflux("PUT", "/entries", json_body={"entry_ids": entry_ids, "status": "read"})
+    return {"updated": entry_ids, "status": "read"}
+
+
+@mcp.tool()
+async def entry_mark_unread(entry_ids: list[int]) -> dict[str, Any]:
+    """Mark one or more entries as unread."""
+    await miniflux("PUT", "/entries", json_body={"entry_ids": entry_ids, "status": "unread"})
+    return {"updated": entry_ids, "status": "unread"}
+
+
+@mcp.tool()
+async def entry_star(entry_id: int) -> dict[str, Any]:
+    """Toggle star on an entry (Miniflux's star endpoint is a toggle)."""
+    await miniflux("PUT", f"/entries/{entry_id}/bookmark")
+    return {"entry_id": entry_id, "starred": "toggled"}
+
+
+@mcp.tool()
+async def feed_refresh(feed_id: int) -> dict[str, Any]:
+    """Force-refresh a feed (fetch immediately, bypassing the scheduler)."""
+    await miniflux("PUT", f"/feeds/{feed_id}/refresh")
+    return {"feed_id": feed_id, "refreshed": True}
+
+
+# ── /health (no auth) ───────────────────────────────────────────────────────
+
+async def health(_request: Request) -> JSONResponse:
+    assert CFG is not None
+    ok = False
+    err: dict[str, str] = {}
+    user_info: dict[str, Any] | None = None
+    try:
+        user_info = await miniflux("GET", "/me")
+        ok = True
+    except Exception as e:  # noqa: BLE001
+        err["miniflux"] = repr(e)
+    return JSONResponse(
+        {
+            "status": "ok" if ok else "degraded",
+            "miniflux_url": CFG.miniflux_url,
+            "user": (user_info or {}).get("username"),
+            **({"errors": err} if err else {}),
+        }
+    )
+
+
+# ── lifespan + main ────────────────────────────────────────────────────────
+
+@asynccontextmanager
+async def lifespan(_app: Starlette):
+    async with mcp.session_manager.run():
+        log.info("miniflux-mcp ready (url=%s)", CFG.miniflux_url if CFG else "?")
+        yield
+
+
+def build_app() -> Starlette:
+    mcp_app = mcp.streamable_http_app()
+    return Starlette(
+        debug=False,
+        routes=[
+            Route("/health", health, methods=["GET"]),
+            Mount("/", app=mcp_app),
+        ],
+        middleware=[Middleware(BearerAuthMiddleware)],
+        lifespan=lifespan,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("MINIFLUX_MCP_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    global CFG, TOKENS_BY_HEX
+    CFG = Config()
+    TOKENS_BY_HEX = load_tokens(CFG.tokens_file)
+    bind_ip = CFG.resolve_bind_ip()
+    log.info(
+        "starting miniflux-mcp on %s:%d (miniflux=%s) with %d client tokens",
+        bind_ip, CFG.port, CFG.miniflux_url, len(TOKENS_BY_HEX),
+    )
+    uvicorn.run(build_app(), host=bind_ip, port=CFG.port, log_level="info")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkgs/miniflux-mcp/pyproject.toml
+++ b/pkgs/miniflux-mcp/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "miniflux-mcp"
+version = "0.1.0"
+description = "MCP server fronting a Miniflux RSS reader instance"
+requires-python = ">=3.11"
+dependencies = [
+  "mcp>=1.15",
+  "starlette>=0.47",
+  "uvicorn>=0.35",
+  "httpx>=0.28",
+]
+
+[project.scripts]
+miniflux-mcp = "miniflux_mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["miniflux_mcp*"]

--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -13,6 +13,9 @@ future_hermes_signal: ENC[AES256_GCM,data:Lh+bg9rGF7ERTtZZcZR+dm4CG5MpDxdVRaDKL7
 future_hermes_radicale: ENC[AES256_GCM,data:T0TeAbnlRkzHWh0vXrk6o/K9xLUDOgB8kr9G1WgyRTaz9CwriGPeVt8aYixJHw7vH6X6OgS64uS4+9i5hQrbjQ==,iv:uKbimchdqJRvF/OiVMtppyuNcKsCHFIRZAwLczUQGQo=,tag:4WF2+TInR2OdPfDjLU9rSw==,type:str]
 radicale_mcp_user: ENC[AES256_GCM,data:TmFp1A==,iv:HF4vcjuy+0StN1rcWE1IJ4d6mNWvr8eDbhaaibTCTLI=,tag:vpEai7HniSsLXn1GoeqmZQ==,type:str]
 radicale_mcp_password: ENC[AES256_GCM,data:HsHBo51fqrhgO9ZibMY=,iv:CX1j2GF3kwmjqUTtK3cdXdb7yP1dMdy5tbC7yP7BQIU=,tag:o85f69XX0IaCIH61QxXgWw==,type:str]
+miniflux_mcp_tokens: ENC[AES256_GCM,data:vavnwoj8xhYAEpus+EROshpXF2rdx2lQZI4VXWNGzcRo0Ha3qdZ7jY7Oox5nTjrDJ3TB90qI21DolmXStP/nETC+7HxUdOM8vSov633wc/lh2/VxL/jsqeiXBE0KkVXWLUEmpvc4mVbCWHKcnGu2L+FNPirhDlO+pT+qS+YfJXXQvHUdzHtw3XWz35wxwjGCNW0k+RsqkE5GIxXm4daYxsZdjiZvO1HR3YVPIETN4H01HZhmDTWfjeDrj5/hzByVwmvSUkCyszjyKqtdx21mSaCC5pNQDzxmNo5NuqJE7MIyNMvvhQs8r6ZUIRVTTIdFnG3VTBEAV7jRcKiSM8Mm7Adb9VvE,iv:EjKAkSdnXylB46KoK/JEJqauQPu4i83sjqrhk8Q0MZY=,tag:kz1jvXaVUIsPdyKOvyOSxg==,type:str]
+future_hermes_miniflux: ENC[AES256_GCM,data:I7fs1IMP3/d0wAw25XCECTZqCcaNO71a81EFeir4j7oc554HYbHUzj8pnXnH6k4m+x9cBpCUwOZlpRazNH8R6g==,iv:EwanYF4ENdW32su1nEwBMkW5cFeEnRQHJFgPNbgB59E=,tag:tHcUVUMt2K5NP2zzKd+tiQ==,type:str]
+miniflux_api_token: ENC[AES256_GCM,data:FdHdDaxViTLuVTm5FrVkKkrr1md746WWp3vmwVoLPtQdv7fQ3DzLNcVYRcyy4lB/nwLj8VUh0ZEbxDIY7Tb2JQ==,iv:mFlWGL/iQSB+7Q/fnqOuT7E/fSuthou7HMc7ka7030I=,tag:+/GggPsyjWnXWAquxKdsHA==,type:str]
 sops:
     age:
         - recipient: age1udcr323x2wxg0ywcy3avq4q7gv9qvxrsuvpen6yve5zh9xaa3s0sfmxvcu
@@ -69,7 +72,7 @@ sops:
             TDBkVitzemVuRFl6TE1wZ0ZHVDNzT0UKmwnKv/hQFjYAOXJUPvvfRCGbU17tiVxL
             r/NSjG+se4lT6BKWrcjZcq0lwsrtKWHriA8ZhMECLW3SwDESzyn22g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-12T00:03:39Z"
-    mac: ENC[AES256_GCM,data:kJCLktBUrcWGnDuH2QdEGxdpOEQrWw4TOJrbL4ONi+D1Ju1RamvXR2iGVrjfdna5MWjCNmcs49ceQlCH4VOqXGMLfWJRqBnVlyPjouARpsdp95ClFMYhmuqfpk26TqAnZwwnd7q5JZX6hYYYxdOf0zYgShpDaR4kQDV1R+4V4NE=,iv:OluXPnA0MSzO/MkU3THLOpD9Loxyi2eIPVDMI8NGyRo=,tag:7XRJ0yEfNbRGnEytbv+n5Q==,type:str]
+    lastmodified: "2026-05-12T00:20:52Z"
+    mac: ENC[AES256_GCM,data:k4iWvqyoMe/FKAm9R1L71GpJWcjSZoZq0OBFhYu/DNhUbteQmggYYKomv1YN+5nR3U7vBhg20Rnhoqg6nwf8OmP7mcgfwYoLnMlGS8f5XFb2ogpzi/U+NXLrWMbGZ4YIPIGKyWbZt45GJhGrqu6lUW0xH/agiOp82gvEZM0pZl0=,iv:4vpjTXpOYSkq9IUP0MfSFm6whi8cVtRB452+Mnf6UeM=,tag:hhlSR3QqDdqJ4BmGO7T5Vw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
Fifth MCP, same shape as the others. Wraps phantom's Miniflux REST API behind bearer-token auth on tailnet :4284. Tools cover the full read/manage surface (feeds, categories, entries with rich filtering, mark-read/unread, star, force-refresh). Wired into Hermes as a fifth tool server.

## Test plan
- [x] nix flake check
- [x] nix build miniflux-mcp + saruman toplevel
- [ ] colmena apply
- [ ] /health returns OK with miniflux user info
- [ ] Hermes journal shows MCP connection to miniflux

🤖 Generated with [Claude Code](https://claude.com/claude-code)