### PR TITLE
chore(hermes): default to Sonnet 4.6

### DIFF
--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -9,11 +9,13 @@ in
 
     model = lib.mkOption {
       type = lib.types.str;
-      default = "anthropic/claude-opus-4.6";
+      default = "anthropic/claude-sonnet-4.6";
       description = ''
         Model identifier for the agent's LLM. Default uses native Anthropic
-        provider; switch to e.g. "openrouter/nousresearch/hermes-3-llama-3.1-405b"
-        and add an OPENROUTER_API_KEY env var in the sops template to migrate.
+        provider with Sonnet 4.6 (fast, cheaper, plenty for Signal-driven
+        tool use). Switch to "anthropic/claude-opus-4.7" for the latest
+        Opus, or "openrouter/nousresearch/hermes-3-llama-3.1-405b" plus an
+        OPENROUTER_API_KEY env var in the sops template to migrate.
       '';
     };
 


### PR DESCRIPTION
Switches the `hermes-agent.model` default from `anthropic/claude-opus-4.6` to `anthropic/claude-sonnet-4.6`. Sonnet is faster + cheaper per token; Opus stays a one-line override.