### PR TITLE
Add hermes-dashboard exposed via Traefik (tailnet + basic auth)

### DIFF
--- a/hosts/common/optional/roles/server/blocky.nix
+++ b/hosts/common/optional/roles/server/blocky.nix
@@ -55,6 +55,7 @@ in
       				"ludus.${tr_secrets.traefik.homelab_domain}" = hosts.atreides.ip;
       				"tts.${tr_secrets.traefik.homelab_domain}" = hosts.atreides.ip;
       				"ntfy.${tr_secrets.traefik.homelab_domain}" = hosts.atreides.ip;
+      				"hermes.${tr_secrets.traefik.homelab_domain}" = hosts.atreides.ip;
       			};
       		};
       		blocking = {

--- a/hosts/common/optional/roles/server/hermes-dashboard/default.nix
+++ b/hosts/common/optional/roles/server/hermes-dashboard/default.nix
@@ -1,0 +1,106 @@
+{ lib, pkgs, config, inputs, ... }:
+let
+  cfg = config.hermes-dashboard;
+  # Build the hermes-agent package (so we can reference $out/share/hermes-agent/web_dist).
+  hermesAgent = inputs.hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in
+{
+  options.hermes-dashboard = {
+    enable = lib.mkEnableOption "Hermes web dashboard (Vite/React) — exposes admin UI behind reverse proxy";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9119;
+      description = "TCP port the dashboard listens on.";
+    };
+
+    bindIp = lib.mkOption {
+      type = lib.types.str;
+      default = "auto";
+      description = ''
+        IPv4 to bind to. "auto" resolves saruman's tailnet IP at service start.
+        The dashboard is unauthenticated at the application layer — auth is
+        provided by the upstream reverse proxy (Traefik basicAuth + IP allowlist).
+      '';
+    };
+
+    tailnetInterface = lib.mkOption {
+      type = lib.types.str;
+      default = "tailscale0";
+      description = "Interface on which to open the dashboard port in the firewall.";
+    };
+
+    tui = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Embed the in-browser Chat tab (proxies a `hermes --tui` session over
+        WebSocket). Convenient for desktop use; the WebSocket inherits the
+        Traefik basicAuth + IP allowlist gates.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.hermes-dashboard = {
+      description = "Hermes web dashboard (admin UI behind Traefik)";
+      after = [
+        "network-online.target"
+        "tailscaled.service"
+        "hermes-agent.service"
+      ];
+      wants = [ "network-online.target" "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ config.services.tailscale.package ];
+
+      # Reuse Hermes's existing EnvironmentFile (Anthropic key, HERMES_*).
+      # The dashboard reads the same .env that the gateway does.
+      serviceConfig.EnvironmentFile = config.sops.templates."hermes-agent.env".path;
+
+      environment = {
+        HERMES_HOME = "/var/lib/hermes/.hermes";
+        # Pin the web dist explicitly so --skip-build serves the right files.
+        HERMES_WEB_DIST = "${hermesAgent}/share/hermes-agent/web_dist";
+      } // lib.optionalAttrs cfg.tui {
+        HERMES_DASHBOARD_TUI = "1";
+      };
+
+      # `hermes dashboard` defaults to 127.0.0.1; we need it on the tailnet
+      # interface so Traefik on atreides can reach it. The Python code expects
+      # an explicit `--insecure` opt-in when binding to non-localhost (the
+      # flag is about the dashboard itself having no auth — Traefik provides
+      # both basicAuth AND an IP allowlist before forwarding here).
+      script = ''
+        set -eu
+        if [ "${cfg.bindIp}" = "auto" ]; then
+          bind=$(tailscale ip -4 | head -n1)
+        else
+          bind="${cfg.bindIp}"
+        fi
+        exec ${hermesAgent}/bin/hermes dashboard \
+          --host "$bind" \
+          --port ${toString cfg.port} \
+          --insecure \
+          --skip-build \
+          --no-open
+      '';
+
+      serviceConfig = {
+        User = "hermes";
+        Group = "hermes";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = false;  # HERMES_HOME lives under /var/lib/hermes
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ReadWritePaths = [ "/var/lib/hermes" ];
+      };
+    };
+
+    # Open the dashboard port to Traefik on atreides over the tailnet.
+    networking.firewall.interfaces.${cfg.tailnetInterface}.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/hosts/common/optional/roles/server/traefik/dynamic-config.nix
+++ b/hosts/common/optional/roles/server/traefik/dynamic-config.nix
@@ -248,6 +248,20 @@ in
 	   				};
 	   				middlewares = [ "auth" "default-headers" "https-redirectscheme" ];
 	   			};
+	   			hermes-dashboard = {
+	   				entryPoints = [ "websecure" ];
+	   				rule = "Host(`hermes.${tr_secrets.traefik.homelab_domain}`)";
+	   				service = "hermes-dashboard";
+	   				tls = {
+	   					certResolver = "cloudflare";
+	   				};
+	   				# Three layers of access control before this reaches the
+	   				# unauthenticated dashboard backend:
+	   				#   hermes-tailnet-only — source IP must be in 100.64.0.0/10
+	   				#   auth                — htpasswd basic auth (shared with other secured services)
+	   				#   default-headers     — security headers (frame-deny, XSS, CSP, etc.)
+	   				middlewares = [ "hermes-tailnet-only" "auth" "default-headers" "https-redirectscheme" ];
+	   			};
 	   		};
 	   		services = {
 	   			# begin Services
@@ -428,6 +442,16 @@ in
 	   					passHostHeader = "true";
 	   				};
 	   			};
+	   			hermes-dashboard = {
+	   				loadBalancer = {
+	   					# Saruman's tailnet IP — dashboard binds to tailnet only,
+	   					# atreides reaches via tailscale0 from its own tailnet IP.
+	   					servers = [
+	   						{url = "http://100.104.242.112:9119";}
+	   					];
+	   					passHostHeader = "true";
+	   				};
+	   			};
 	   		};
 	   		 middlewares = {
 	   			default-headers = {
@@ -475,6 +499,17 @@ in
 	   						"10.0.0.0/8"
 	   						"192.168.0.0/16"
 	   						"172.16.0.0/12"
+	   					];
+	   				};
+	   			};
+	   			# Tailnet-only: only source IPs in Tailscale's CGNAT range can
+	   			# reach the gated router. Combined with basicAuth this gives
+	   			# two-layer access control before the unauthenticated Hermes
+	   			# dashboard backend ever sees the request.
+	   			hermes-tailnet-only = {
+	   				ipWhiteList = {
+	   					sourceRange = [
+	   						"100.64.0.0/10"
 	   					];
 	   				};
 	   			};

--- a/hosts/saruman/configuration.nix
+++ b/hosts/saruman/configuration.nix
@@ -8,6 +8,9 @@
       ../common/optional/roles/server/hermes-agent  # saruman-only — depends on
                                                     # upstream services.hermes-agent
                                                     # option from the flake input
+      ../common/optional/roles/server/hermes-dashboard  # saruman-only — pulls
+                                                        # the upstream hermes-agent
+                                                        # package out of the input
       ../common/optional/roles/workstation
       ../../disko/saruman.nix
     ];
@@ -36,6 +39,7 @@
   signal-mcp.enable = true;    # outbound Signal MCP with approval gate
   radicale-mcp.enable = true;  # CalDAV/CardDAV MCP (talks to phantom's Radicale)
   miniflux-mcp.enable = true;  # Miniflux RSS reader MCP (talks to phantom's Miniflux)
+  hermes-dashboard.enable = true;  # web UI behind traefik (auth + tailnet allowlist)
 
 
   boot.loader.systemd-boot.enable = true;


### PR DESCRIPTION
Exposes `hermes dashboard` (the upstream Vite/React admin UI bundled with hermes-agent) behind Traefik on `hermes.\<homelab_domain\>` with three layers of access control: tailnet-source-IP allowlist (`100.64.0.0/10`), htpasswd basic auth (the existing shared `auth` middleware), and security headers. The dashboard itself runs unauthenticated on saruman's tailnet IP:9119 — the upstream's `--insecure` flag is the explicit opt-in for that.

## Test plan
- [x] nix flake check
- [x] nix build saruman + atreides toplevels
- [ ] colmena apply --on @vm + saruman
- [ ] DNS resolves hermes.\<domain\> to atreides
- [ ] HTTPS cert resolves via Let's Encrypt (cloudflare provider)
- [ ] From phone on tailnet: prompted for basic auth, then dashboard loads
- [ ] From phone OFF tailnet: DNS doesn't resolve (since blocky is internal-only)
- [ ] WebSocket chat tab works (HERMES_DASHBOARD_TUI=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)