### PR TITLE
chore(traefik): widen hermes-dashboard allowlist to include homelab LAN

### DIFF
--- a/hosts/common/optional/roles/server/traefik/dynamic-config.nix
+++ b/hosts/common/optional/roles/server/traefik/dynamic-config.nix
@@ -257,10 +257,13 @@ in
 	   				};
 	   				# Three layers of access control before this reaches the
 	   				# unauthenticated dashboard backend:
-	   				#   hermes-tailnet-only — source IP must be in 100.64.0.0/10
+	   				#   hermes-allowed-nets — source IP in tailnet (100.64.0.0/10)
+	   				#                         OR homelab LAN (10.1.8.0/24). The phone
+	   				#                         takes the LAN route when on home WiFi,
+	   				#                         so tailnet-only would reject normal use.
 	   				#   auth                — htpasswd basic auth (shared with other secured services)
 	   				#   default-headers     — security headers (frame-deny, XSS, CSP, etc.)
-	   				middlewares = [ "hermes-tailnet-only" "auth" "default-headers" "https-redirectscheme" ];
+	   				middlewares = [ "hermes-allowed-nets" "auth" "default-headers" "https-redirectscheme" ];
 	   			};
 	   		};
 	   		services = {
@@ -502,14 +505,17 @@ in
 	   					];
 	   				};
 	   			};
-	   			# Tailnet-only: only source IPs in Tailscale's CGNAT range can
-	   			# reach the gated router. Combined with basicAuth this gives
-	   			# two-layer access control before the unauthenticated Hermes
-	   			# dashboard backend ever sees the request.
-	   			hermes-tailnet-only = {
+	   			# Source IP allowlist for the Hermes dashboard router. Combined
+	   			# with basicAuth this gives two-layer access control before the
+	   			# unauthenticated Hermes dashboard backend ever sees the request.
+	   			# Includes the homelab LAN because phones on home WiFi route via
+	   			# LAN, not via tailnet — strict tailnet-only would block the
+	   			# common case.
+	   			hermes-allowed-nets = {
 	   				ipWhiteList = {
 	   					sourceRange = [
-	   						"100.64.0.0/10"
+	   						"100.64.0.0/10"  # Tailscale CGNAT
+	   						"10.1.8.0/24"    # homelab LAN (saruman/atreides/phantom)
 	   					];
 	   				};
 	   			};


### PR DESCRIPTION
Phone on home WiFi takes the LAN route to atreides (source IP 10.1.8.x), so the original `100.64.0.0/10` tailnet-only middleware rejected normal home use. Adds 10.1.8.0/24 and renames the middleware to `hermes-allowed-nets` for accuracy. BasicAuth is still the primary gate.