### PR TITLE
Add vault-indexer: hourly Obsidian vault → agent_memory pipeline

### DIFF
--- a/hosts/common/optional/roles/server/default.nix
+++ b/hosts/common/optional/roles/server/default.nix
@@ -33,6 +33,7 @@
     ./signal-mcp
     ./radicale-mcp
     ./miniflux-mcp
+    ./vault-indexer
     # ./hermes-agent  — imported on saruman only (hosts/saruman/configuration.nix)
     # because it sets services.hermes-agent.* which only exists where the
     # upstream NousResearch/hermes-agent NixOS module is loaded.

--- a/hosts/common/optional/roles/server/vault-indexer/default.nix
+++ b/hosts/common/optional/roles/server/vault-indexer/default.nix
@@ -1,0 +1,88 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.vault-indexer;
+in
+{
+  options.vault-indexer = {
+    enable = lib.mkEnableOption "periodic vault → agent_memory indexer";
+
+    vaultRoot = lib.mkOption {
+      type = lib.types.path;
+      default = "/home/alex/obsidian/Barrow-Downs";
+      description = "Path to the Obsidian vault to index.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "alex";
+      description = ''
+        UNIX user that runs the indexer. Must be able to read the vault
+        directory. Default `alex` matches the vault owner; the user also
+        needs to read the bearer-token secret file (we own-it to `alex`
+        in the sops declaration).
+      '';
+    };
+
+    agentMemoryUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://100.104.242.112:4280/mcp";
+      description = "Streamable-HTTP URL for the agent-memory MCP server.";
+    };
+
+    onCalendar = lib.mkOption {
+      type = lib.types.str;
+      default = "hourly";
+      description = "systemd OnCalendar spec for the indexer timer.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Bearer token used by the indexer to call agent-memory-mcp. Owned by
+    # the indexer's runtime user so it can read the value.
+    sops.secrets.vault_indexer_agent_memory_token = {
+      owner = cfg.user;
+      group = "users";
+      mode = "0400";
+    };
+
+    systemd.services.vault-indexer = {
+      description = "Index vault chunks into agent_memory";
+      after = [
+        "network-online.target"
+        "tailscaled.service"
+        "agent-memory-mcp.service"
+      ];
+      wants = [ "network-online.target" "tailscaled.service" ];
+
+      environment = {
+        VAULT_INDEXER_VAULT = builtins.toString cfg.vaultRoot;
+        VAULT_INDEXER_AGENT_MEMORY_URL = cfg.agentMemoryUrl;
+        VAULT_INDEXER_TOKEN_FILE = config.sops.secrets.vault_indexer_agent_memory_token.path;
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.vault-indexer}/bin/vault-indexer";
+        User = cfg.user;
+        Group = "users";
+        # Modest hardening; the indexer only needs to read the vault and
+        # speak HTTP outbound.
+        ProtectSystem = "strict";
+        ProtectHome = false;  # vault is under /home
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+      };
+    };
+
+    systemd.timers.vault-indexer = {
+      description = "Run vault-indexer on a schedule";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.onCalendar;
+        Persistent = true;          # fire missed runs at boot — handles initial bootstrap
+        RandomizedDelaySec = "5min"; # jitter so we don't slam Ollama at exactly :00
+        Unit = "vault-indexer.service";
+      };
+    };
+  };
+}

--- a/hosts/saruman/configuration.nix
+++ b/hosts/saruman/configuration.nix
@@ -40,6 +40,7 @@
   radicale-mcp.enable = true;  # CalDAV/CardDAV MCP (talks to phantom's Radicale)
   miniflux-mcp.enable = true;  # Miniflux RSS reader MCP (talks to phantom's Miniflux)
   hermes-dashboard.enable = true;  # web UI behind traefik (auth + tailnet allowlist)
+  vault-indexer.enable = true;  # hourly: chunk vault → embed → agent_memory
 
 
   boot.loader.systemd-boot.enable = true;

--- a/pkgs/agent-memory-mcp/agent_memory_mcp/server.py
+++ b/pkgs/agent-memory-mcp/agent_memory_mcp/server.py
@@ -229,6 +229,47 @@ async def memory_search(
 
 
 @mcp.tool()
+async def memory_list_by_source(
+    source_prefix: str,
+    limit: int = 10000,
+) -> list[dict[str, Any]]:
+    """List memories whose `source` starts with `source_prefix`. Used by
+    indexer-style clients (e.g., vault-indexer) to enumerate existing
+    rows for a content namespace and reconcile them with the source-of-
+    truth on disk.
+
+    Returns id + source + metadata + tags (no embedding, no content).
+    """
+    conn = await db()
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT m.id, m.source, m.tags, m.metadata, m.created_at, m.updated_at,
+                   p.name AS project
+            FROM memories m
+            LEFT JOIN projects p ON p.id = m.project_id
+            WHERE m.source LIKE %s
+            ORDER BY m.source
+            LIMIT %s
+            """,
+            (source_prefix + "%", limit),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "id": str(r["id"]),
+            "source": r["source"],
+            "project": r["project"],
+            "tags": r["tags"],
+            "metadata": r["metadata"],
+            "created_at": r["created_at"].isoformat(),
+            "updated_at": r["updated_at"].isoformat(),
+        }
+        for r in rows
+    ]
+
+
+@mcp.tool()
 async def memory_insert(
     content: str,
     project: str | None = None,

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,4 +7,5 @@
   signal-mcp = pkgs.callPackage ./signal-mcp { python3 = pkgs.python3; };
   radicale-mcp = pkgs.callPackage ./radicale-mcp { python3 = pkgs.python3; };
   miniflux-mcp = pkgs.callPackage ./miniflux-mcp { python3 = pkgs.python3; };
+  vault-indexer = pkgs.callPackage ./vault-indexer { python3 = pkgs.python3; };
 }

--- a/pkgs/vault-indexer/default.nix
+++ b/pkgs/vault-indexer/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "vault-indexer";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  dependencies = with python3.pkgs; [
+    mcp
+    httpx
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Periodic chunker + embedder mirroring an Obsidian vault into agent_memory";
+    license = licenses.mit;
+    mainProgram = "vault-indexer";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/vault-indexer/pyproject.toml
+++ b/pkgs/vault-indexer/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vault-indexer"
+version = "0.1.0"
+description = "Periodic chunker + embedder that mirrors an Obsidian vault into agent_memory pgvector"
+requires-python = ">=3.11"
+dependencies = [
+  "mcp>=1.15",
+  "httpx>=0.28",
+]
+
+[project.scripts]
+vault-indexer = "vault_indexer.main:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["vault_indexer*"]

--- a/pkgs/vault-indexer/vault_indexer/main.py
+++ b/pkgs/vault-indexer/vault_indexer/main.py
@@ -1,0 +1,223 @@
+"""Vault indexer: reconciles an Obsidian vault directory into agent_memory.
+
+For every Markdown file under the vault root, splits the file into chunks
+by Markdown header (H1/H2/H3) with a per-chunk token budget (~500 tokens).
+Each chunk is inserted into agent_memory under project='vault' with
+source='vault:<relative path>#<heading-anchor>' and metadata.sha256 of the
+chunk content. On subsequent runs, chunks whose sha256 hasn't changed are
+skipped; changed chunks are deleted + re-inserted; orphaned rows (the
+note no longer exists on disk, or the heading was renamed) are removed.
+
+Driven by a systemd timer. Designed to be a one-way mirror — the LLM
+never writes back to the vault from agent_memory (vault-mcp does that
+separately, behind its own auth).
+
+Talks to agent-memory-mcp over HTTP with a bearer token. Reads vault
+files directly off disk (service user must have read access).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+log = logging.getLogger("vault_indexer")
+
+# Skip these top-level dirs and any dotfile in general.
+SKIP_PREFIXES = (".obsidian", ".trash", ".git")
+TEXT_EXTENSIONS = (".md",)
+# Rough token estimate: ~4 chars per token. Cap chunks at 500 tokens.
+MAX_CHARS_PER_CHUNK = 2000
+HEADING_RE = re.compile(r"^(#{1,3})\s+(.+?)\s*$")
+
+
+# ── chunking ────────────────────────────────────────────────────────────────
+
+def slugify(s: str) -> str:
+    """Make a heading-anchor-safe slug for use in the source key."""
+    s = re.sub(r"[^A-Za-z0-9\s-]", "", s)
+    s = re.sub(r"\s+", "-", s.strip())
+    return s.lower()[:80] or "section"
+
+
+def chunk_markdown(text: str) -> list[tuple[str, str]]:
+    """Split a Markdown document into (heading_slug, chunk_text) pairs.
+
+    Strategy:
+      1. Walk lines; whenever a #/##/### heading is hit, start a new section.
+      2. Content before the first heading goes under slug='preamble'.
+      3. If a section exceeds MAX_CHARS_PER_CHUNK, split it into N parts
+         with suffixes '#part1', '#part2', etc.
+    """
+    sections: list[tuple[str, list[str]]] = []
+    current_heading = "preamble"
+    current_buf: list[str] = []
+    for line in text.splitlines():
+        m = HEADING_RE.match(line)
+        if m:
+            if current_buf:
+                sections.append((current_heading, current_buf))
+            current_heading = slugify(m.group(2))
+            current_buf = [line]
+        else:
+            current_buf.append(line)
+    if current_buf:
+        sections.append((current_heading, current_buf))
+
+    chunks: list[tuple[str, str]] = []
+    for slug, lines in sections:
+        body = "\n".join(lines).strip()
+        if not body:
+            continue
+        if len(body) <= MAX_CHARS_PER_CHUNK:
+            chunks.append((slug, body))
+            continue
+        # Split oversize sections into roughly-equal parts on paragraph
+        # boundaries when possible. Suffix with #part<N>.
+        paragraphs = body.split("\n\n")
+        buf = ""
+        part = 1
+        for p in paragraphs:
+            if buf and len(buf) + len(p) + 2 > MAX_CHARS_PER_CHUNK:
+                chunks.append((f"{slug}#part{part}", buf.strip()))
+                buf = p
+                part += 1
+            else:
+                buf = (buf + "\n\n" + p) if buf else p
+        if buf.strip():
+            chunks.append((f"{slug}#part{part}" if part > 1 else slug, buf.strip()))
+    return chunks
+
+
+def iter_notes(vault_root: Path):
+    """Yield Path objects for every Markdown file under the vault root,
+    skipping dotfiles and the .obsidian/.trash/.git roots."""
+    for p in vault_root.rglob("*"):
+        if not p.is_file():
+            continue
+        rel_parts = p.relative_to(vault_root).parts
+        if any(part.startswith(".") for part in rel_parts):
+            continue
+        if rel_parts and rel_parts[0] in SKIP_PREFIXES:
+            continue
+        if p.suffix.lower() in TEXT_EXTENSIONS:
+            yield p
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ── agent-memory client wrapper ─────────────────────────────────────────────
+
+@asynccontextmanager
+async def open_session(url: str, bearer: str):
+    headers = {"Authorization": f"Bearer {bearer}"}
+    async with streamablehttp_client(url, headers=headers) as (read, write, _close):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def call_tool(session: ClientSession, name: str, args: dict[str, Any]) -> Any:
+    result = await session.call_tool(name, args)
+    if result.isError:
+        text = " ".join(getattr(b, "text", "") for b in result.content)
+        raise RuntimeError(f"tool {name} failed: {text}")
+    # Most tools return a structuredContent with `result` or a single dict.
+    if result.structuredContent is not None:
+        sc = result.structuredContent
+        return sc.get("result", sc)
+    # Fallback: concat text blocks.
+    return " ".join(getattr(b, "text", "") for b in result.content)
+
+
+# ── main reconciliation ────────────────────────────────────────────────────
+
+async def reconcile(vault_root: Path, am_url: str, bearer: str) -> None:
+    async with open_session(am_url, bearer) as session:
+        # 1. Snapshot existing vault: rows in agent_memory under source LIKE 'vault:%'.
+        existing = await call_tool(session, "memory_list_by_source", {"source_prefix": "vault:"})
+        by_source: dict[str, dict[str, Any]] = {row["source"]: row for row in (existing or [])}
+        log.info("found %d existing vault chunks in agent_memory", len(by_source))
+
+        # 2. Walk disk, build set of desired sources.
+        desired: set[str] = set()
+        upsert_count = 0
+        skip_count = 0
+        for path in iter_notes(vault_root):
+            rel = str(path.relative_to(vault_root))
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except OSError as e:
+                log.warning("skipping %s: %s", rel, e)
+                continue
+            chunks = chunk_markdown(raw)
+            top_folder = path.relative_to(vault_root).parts[0] if path.relative_to(vault_root).parts else ""
+            for slug, content in chunks:
+                source = f"vault:{rel}#{slug}"
+                desired.add(source)
+                sha = sha256_text(content)
+                row = by_source.get(source)
+                if row and (row.get("metadata") or {}).get("sha256") == sha:
+                    skip_count += 1
+                    continue
+                # Changed (or new): delete old then insert fresh. The MCP
+                # doesn't have an upsert; delete-insert is idempotent enough
+                # at hourly cadence.
+                if row:
+                    await call_tool(session, "memory_delete", {"id": row["id"]})
+                tags = ["vault"]
+                if top_folder:
+                    tags.append(top_folder)
+                metadata = {"sha256": sha, "path": rel, "heading": slug}
+                await call_tool(session, "memory_insert", {
+                    "content": content,
+                    "project": "vault",
+                    "source": source,
+                    "tags": tags,
+                    "metadata": metadata,
+                })
+                upsert_count += 1
+
+        # 3. Delete orphans (rows that no longer have a matching on-disk source).
+        orphans = [row for src, row in by_source.items() if src not in desired]
+        for row in orphans:
+            await call_tool(session, "memory_delete", {"id": row["id"]})
+
+        log.info(
+            "vault reconcile complete: %d upserts, %d unchanged, %d orphans removed",
+            upsert_count, skip_count, len(orphans),
+        )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("VAULT_INDEXER_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    vault_root = Path(os.environ["VAULT_INDEXER_VAULT"]).resolve()
+    am_url = os.environ["VAULT_INDEXER_AGENT_MEMORY_URL"].rstrip("/")
+    token_file = os.environ["VAULT_INDEXER_TOKEN_FILE"]
+    if not vault_root.is_dir():
+        raise SystemExit(f"vault root not a directory: {vault_root}")
+    with open(token_file) as f:
+        bearer = f.read().strip()
+    log.info("vault-indexer starting (vault=%s am=%s)", vault_root, am_url)
+    asyncio.run(reconcile(vault_root, am_url, bearer))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/secrets/main.yaml
+++ b/secrets/main.yaml
@@ -1,6 +1,6 @@
 alex_hash: ENC[AES256_GCM,data:wPEzo4HDQPBRKxmhZeDPsCs8QrhzPPaopSIqmXWPrmztZ5LQlg1elbYbEOWFS8hv20oJNPoP4VjBls8p/nIceXxmginXRwNj9Q==,iv:SZMa7wpGx0WjCQ28PCV11BZN6sCVRCzwI/Vjlwjor9o=,tag:H4SpMhLf0e82L+V6T4j0rQ==,type:str]
 tskey-reusable: ENC[AES256_GCM,data:3t9xz8MDnZg5mlxdyPKajqB6ldjFtErpw7U5oFzq46NTEiLdmUW0xweA9fTFHi0XseHlx65TfOYI7jSvpg==,iv:bvGRHcP+DFrqw9hzcXUhLLW9uZT6nLFFLI71MM4QGIg=,tag:klZhILl22ToJGtWOhDTjSg==,type:str]
-agent_memory_mcp_tokens: ENC[AES256_GCM,data:qPE6eNb3WAIdQZU/7MauS+izdEBX09UnYgxxrBzgN5Fs8+/Laa8YFdDRjbeZmvXOcYpZL0iFQ3DrkOoJLc5P3ifrtO2XCRe//PLYhYxMhV9BCdroIxOrUezf3GJZi41kmkkd/pqtlzthMuiBvh1o+7mXjO5FWk1TzoDru77Mu/DVd5G+6o+tmLGfEwrnqcs+nIg+4nRheU21D9O9tRqz56BseHzHRQoUgL//oh3NBcHDP7Fqs7KIwcikp2PrADl0WDosSi6rJJR/OTwi7mIl7tHv7lMxttQnQcdRrIHB0hJYGykZF6x8xFKxNzDd3kWyGIH0FmKG8pLAa9HyuUuYC1M84jXw,iv:ufITAD3JcGzPOLh5Nn/TPcx1ScvuSwwekunLiEgtpM8=,tag:t/OcOZtD1KGhLBYTGNzg3Q==,type:str]
+agent_memory_mcp_tokens: ENC[AES256_GCM,data:9TRE2kVCoD9t6r2fXzIrdNHeHaltpLdlV4EPoJemBDMReHyyKq+h/1UHfK9aTwPAk3Rd6Qez061qWZOUwpn820W4s/NmaTh95MydzJzA2khJGMsEZxFmIGBoT9uqwcHK5HAqf1ZgrinfH83cus+rpGZ7RiwQNuHqrJZ3DTgkZn9N0ny+JZoncJb7I275uZ9rJABujDlBCtu4ktkF3/yXLkicEBJERtnyijHTXCMvg4dXx4E6bSwOCjQoeREh/s+85bODTqJebieie+AcrAidtTfEtHpwO0YIp+mVFl2MGOVWybqASBoF9OMnpi4muTCtqLxHOv+8HkEro3/OB6mGHulumt3vR5T5jwz9KZnMOBqKFrGsKaZNp+YVh3eYIwjEA0zYvSuDnejSHT2NRkGmqMX2Qz4A33wYpNgHnghSdFl/UNH3hElwEJtcOISr8ARbXOvXA2eqfmFP/CzKOvVpCdifbjOHDiCN1rtzyEgrIQiheJu2z+0IIg==,iv:5rHGYQREAVPfx3gfWefBVVc5WHHgb177UfPWB+F2eRY=,tag:46xlWufVXr8dr1kvNncgqg==,type:str]
 vault_mcp_tokens: ENC[AES256_GCM,data:ft7GY9b3LG8T2Ef9v+gqWIlaI0uLBgE0jIFAFrew+3dfMAaPOFraw5Nq/FILShOhHzgJLgfOVcSq7j9ZFB9m/I55e9zvusGXda3o/C6z8fUmYGdzWld3097v94DWxAm7ngXOg8jNcEJS2dA17dUrqbQ+xagebgdYON3WJIHfochlsljSshrdVm1K/cvepoUBbvK2qxWwBIOQldGwqPy0QljpcLwDzHpX2qT9ooi0qoBJlmzGjDI5FQBf//IrESX3JS9rVnXDWmwujsrpXQJhm3bkyAJV78hTt2ilzqhBdjTzpsBkyNraS0W9SS14Gxe4QHyfeDnVUb15lC0Nj4PIHCoc04BH,iv:g5GRZitrwPmJFmZk+DLB9kWqWRh0u5xtkF7Fya7GKQs=,tag:KBN5KPHf6QUcRAo7SATnSg==,type:str]
 anthropic_api_key: ENC[AES256_GCM,data:rlOoVIBUJKy8ZOkJ0puzwnkFEXxkibBKwB8XW8x8D8KfOsXHtKETjjU6ojqAh44rXxAgOJULSc1mA4uN5sFca7KFsImxrzQT2b7EXguWZgoOyg5lxfA3YUS1KzWC0Ghh7JDW2KDCFZ8zutpP,iv:mxOh7v35fa1j++IoyequkESox6CRgXqQlXjYtkjQcng=,tag:bZzSNtmVBCxPEyWwkyhrLA==,type:str]
 hermes_bot_account: ENC[AES256_GCM,data:SnXgC/xbrNd9heNK,iv:2+Wzj5jsvVgIw7JaMAhXVPGGAi5VMBLoiBiDyQljT0U=,tag:rqjzWS6YaH7Uygjy3hNM8w==,type:str]
@@ -16,6 +16,7 @@ radicale_mcp_password: ENC[AES256_GCM,data:HsHBo51fqrhgO9ZibMY=,iv:CX1j2GF3kwmjq
 miniflux_mcp_tokens: ENC[AES256_GCM,data:vavnwoj8xhYAEpus+EROshpXF2rdx2lQZI4VXWNGzcRo0Ha3qdZ7jY7Oox5nTjrDJ3TB90qI21DolmXStP/nETC+7HxUdOM8vSov633wc/lh2/VxL/jsqeiXBE0KkVXWLUEmpvc4mVbCWHKcnGu2L+FNPirhDlO+pT+qS+YfJXXQvHUdzHtw3XWz35wxwjGCNW0k+RsqkE5GIxXm4daYxsZdjiZvO1HR3YVPIETN4H01HZhmDTWfjeDrj5/hzByVwmvSUkCyszjyKqtdx21mSaCC5pNQDzxmNo5NuqJE7MIyNMvvhQs8r6ZUIRVTTIdFnG3VTBEAV7jRcKiSM8Mm7Adb9VvE,iv:EjKAkSdnXylB46KoK/JEJqauQPu4i83sjqrhk8Q0MZY=,tag:kz1jvXaVUIsPdyKOvyOSxg==,type:str]
 future_hermes_miniflux: ENC[AES256_GCM,data:I7fs1IMP3/d0wAw25XCECTZqCcaNO71a81EFeir4j7oc554HYbHUzj8pnXnH6k4m+x9cBpCUwOZlpRazNH8R6g==,iv:EwanYF4ENdW32su1nEwBMkW5cFeEnRQHJFgPNbgB59E=,tag:tHcUVUMt2K5NP2zzKd+tiQ==,type:str]
 miniflux_api_token: ENC[AES256_GCM,data:FdHdDaxViTLuVTm5FrVkKkrr1md746WWp3vmwVoLPtQdv7fQ3DzLNcVYRcyy4lB/nwLj8VUh0ZEbxDIY7Tb2JQ==,iv:mFlWGL/iQSB+7Q/fnqOuT7E/fSuthou7HMc7ka7030I=,tag:+/GggPsyjWnXWAquxKdsHA==,type:str]
+vault_indexer_agent_memory_token: ENC[AES256_GCM,data:sZqUxhSH+X2JNWy3qRO7aXprFYavCAjRZPOsgOZTRJmo9lr/oemgiKI12c+Tt4jjNxMDlWvMGu0Tgz4GjpZkpA==,iv:Dbg4Ffm5vV5RUQf2guwRRZ4wui2PEAtYcUHbYEPLWuA=,tag:yA6bFZ2Rr6VOqPG3CIB7dQ==,type:str]
 sops:
     age:
         - recipient: age1udcr323x2wxg0ywcy3avq4q7gv9qvxrsuvpen6yve5zh9xaa3s0sfmxvcu
@@ -72,7 +73,7 @@ sops:
             TDBkVitzemVuRFl6TE1wZ0ZHVDNzT0UKmwnKv/hQFjYAOXJUPvvfRCGbU17tiVxL
             r/NSjG+se4lT6BKWrcjZcq0lwsrtKWHriA8ZhMECLW3SwDESzyn22g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-12T00:20:52Z"
-    mac: ENC[AES256_GCM,data:k4iWvqyoMe/FKAm9R1L71GpJWcjSZoZq0OBFhYu/DNhUbteQmggYYKomv1YN+5nR3U7vBhg20Rnhoqg6nwf8OmP7mcgfwYoLnMlGS8f5XFb2ogpzi/U+NXLrWMbGZ4YIPIGKyWbZt45GJhGrqu6lUW0xH/agiOp82gvEZM0pZl0=,iv:4vpjTXpOYSkq9IUP0MfSFm6whi8cVtRB452+Mnf6UeM=,tag:hhlSR3QqDdqJ4BmGO7T5Vw==,type:str]
+    lastmodified: "2026-05-12T03:59:42Z"
+    mac: ENC[AES256_GCM,data:6RdN2ouxbUlafwRcBBEhpEgBgsjnPd5TEMLEztpFDKyvu5+2caHyHjbJs8Hg9ztLMhA+EVS0hgSt3r9qQCN1qK1iQlkdFrTt2gBgctbQoq07TWWputXg2q86e5UBZIapCrfqntHo7BLM9Vp/9I9MApeGBxaZwzeeDmdfYrFnO1M=,iv:i2ci/R0ODJUwYytt9dNcgRV8ets2dDHXgOpyrMP5sAA=,tag:jGS2t+WCBpTNIXROF9vTuQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
Phase 4 first chunk. Chunks every Markdown note in Barrow-Downs by H1/H2/H3 (500-token cap), upserts into `agent_memory` under `project='vault'` with sha256 fingerprints for incremental re-embed and orphan cleanup. Hourly systemd timer with `Persistent=true` so the bootstrap run fires after first boot. Adds `memory_list_by_source` to agent-memory-mcp and a new `vault-indexer` bearer-token client.

After this: `memory_search` returns hits from your actual vault notes too — the unified-brain win.

## Test plan
- [x] nix flake check
- [x] nix build vault-indexer + saruman toplevel
- [ ] colmena apply --on saruman
- [ ] First scheduled run completes (or trigger manually: `sudo systemctl start vault-indexer.service`)
- [ ] `project_list` shows the new `vault` project
- [ ] `memory_search` returns hits for a phrase known to exist in a vault note

🤖 Generated with [Claude Code](https://claude.com/claude-code)