### PR TITLE
fix(agent-memory-mcp): coerce embedding components to float

### DIFF
--- a/pkgs/agent-memory-mcp/agent_memory_mcp/server.py
+++ b/pkgs/agent-memory-mcp/agent_memory_mcp/server.py
@@ -146,7 +146,11 @@ async def embed(text: str) -> list[float]:
             raise RuntimeError(
                 f"Ollama returned unexpected embedding shape: len={len(vec) if isinstance(vec, list) else 'n/a'}; expected {EMBED_DIM}"
             )
-        return vec
+        # Coerce every element to float. Ollama returns JSON numbers; json.loads
+        # parses integer-valued elements (0, 1, -2) as Python int rather than
+        # float, and psycopg's pgvector adapter rejects mixed-type lists with
+        # "cannot dump lists of mixed types; got: float, int".
+        return [float(x) for x in vec]
 
 
 # ── project resolution ────────────────────────────────────────────────────────


### PR DESCRIPTION
Ollama embeddings sometimes have integer-valued components (0, 1, -2 etc.) which Python parses as `int`, mixed with `float` in the same list. psycopg's pgvector adapter rejects mixed-type lists. Cast every element to float in the central `embed()` helper. This broke the vault-indexer mid-run after ~1140 successful inserts; the indexer will resume from sha256 fingerprints on next trigger.