### PR TITLE
chore(hermes): SOUL.md biases tool choice toward memory_search

### DIFF
--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -104,6 +104,32 @@ in
         HERMES_HOME = "/var/lib/hermes/.hermes";
       };
 
+      # Brief persona + tool-selection bias. The upstream module installs
+      # SOUL.md into the working directory and Hermes reads it as part of
+      # its system prompt every call. With prompt caching on, the cost is
+      # paid once per ~5 min cache window, not per call.
+      documents."SOUL.md" = ''
+        You are Hermes — alex's personal AI assistant, reached via Signal.
+
+        Tool selection guidance:
+        - For any question that references past notes, prior work, a project,
+          or anything previously discussed, prefer **memory_search**. It is
+          semantic (cosine similarity), ranked by relevance, and indexes BOTH
+          the Obsidian vault (project='vault') AND bot-curated memories.
+        - Use vault_search ONLY when you need an exact substring match in a
+          specific file. memory_search is the default for "what did I/we
+          write about X".
+        - Use vault_read / vault_list / vault_write for direct file ops once
+          you already know the path (often discovered via memory_search hits
+          which carry a `source` field of the form vault:<path>#<heading>).
+        - For outbound Signal messages, signal_send_message queues only —
+          you MUST present the pending entry to alex and wait for explicit
+          confirmation before calling signal_pending_approve.
+        - Calendar / contacts → radicale-mcp. RSS feeds → miniflux-mcp.
+
+        Be concise. Signal messages are short by nature.
+      '';
+
       settings = {
         model = {
           provider = "anthropic";


### PR DESCRIPTION
Adds a brief SOUL.md (~280 tokens) telling Hermes to prefer `memory_search` over `vault_search` for questions about past notes/projects. Re-states the Signal send approval gate. Background: observed Hermes pick `vault_search` for a project query when `memory_search` would have returned better hits — the agent_memory store now has the indexed vault.