### PR TITLE
fix(deploy): gate tailnet services on tailscale readiness; trust settled health check

### DIFF
--- a/hosts/common/optional/roles/server/hermes-agent/service.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/service.nix
@@ -421,6 +421,11 @@ in
       # its HTTP endpoint accepts connections, and hermes loses that race
       # on cold deploys. Poll until the daemon responds (or 30s timeout).
       serviceConfig.ExecStartPre = [
+        # hermes also resolves its own tailnet bind IP via `tailscale ip -4`
+        # at start, so it loses the same tailscaled-restart race as the MCPs
+        # (see mcp/default.nix for the full rationale). Gate on tailscale
+        # readiness first, then wait on signal-cli below.
+        "${pkgs.wait-tailnet-ip}/bin/wait-tailnet-ip"
         (pkgs.writeShellScript "wait-for-signal-cli" ''
           set -eu
           url="http://127.0.0.1:${toString signalCfg.httpPort}/api/v1/rpc"

--- a/hosts/common/optional/roles/server/mcp/default.nix
+++ b/hosts/common/optional/roles/server/mcp/default.nix
@@ -1,4 +1,29 @@
-{ ... }:
+{ lib, pkgs, config, ... }:
+let
+  # Every MCP gateway binds to the host's tailnet IPv4, resolved at service
+  # start via `tailscale ip -4`. `After=tailscaled.service` (set in each unit)
+  # only orders process *spawn*, not readiness: on a deploy that restarts
+  # tailscaled, the daemon goes "active" several seconds before it has
+  # re-established the tunnel and reassigned the IP. Every MCP then loses that
+  # race and exits 1 with `bind ip: tailscale ip -4: exit status 1`. systemd's
+  # Restart= heals them within ~5s, but colmena snapshots the failure and the
+  # deploy is reported failed (exit 4). Gate each MCP on tailscale readiness so
+  # they come up clean on the first try. Defined centrally — rather than in
+  # each module — so the rationale lives in one place; this merges with each
+  # unit's own serviceConfig.
+  waitTailnetIp = "${pkgs.wait-tailnet-ip}/bin/wait-tailnet-ip";
+  tailnetMcpUnits = {
+    agent-memory-mcp = config.agent-memory.enable;
+    email-mcp        = config.email-mcp.enable;
+    escalator-mcp    = config.escalator-mcp.enable;
+    gcal-mcp         = config.gcal-mcp.enable;
+    miniflux-mcp     = config.miniflux-mcp.enable;
+    prometheus-mcp   = config.prometheus-mcp.enable;
+    radicale-mcp     = config.radicale-mcp.enable;
+    signal-mcp       = config.signal-mcp.enable;
+    vault-mcp        = config.vault-mcp.enable;
+  };
+in
 {
   # ─── MCP server modules ──────────────────────────────────────────────────
   # All NixOS modules that host an MCP service live under this directory.
@@ -21,4 +46,11 @@
     ./signal
     ./vault
   ];
+
+  # Prepend the tailnet-readiness gate to every enabled MCP unit (see above).
+  config.systemd.services = lib.mapAttrs
+    (_unit: enabled: lib.mkIf enabled {
+      serviceConfig.ExecStartPre = [ waitTailnetIp ];
+    })
+    tailnetMcpUnits;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -22,4 +22,5 @@
   hermes-skill-obsidian = pkgs.callPackage ./hermes-skill-obsidian { };
   antigravity-cli = pkgs.callPackage ./antigravity-cli { };
   openwhispr = pkgs.callPackage ./openwhispr { };
+  wait-tailnet-ip = pkgs.callPackage ./wait-tailnet-ip { };
 }

--- a/pkgs/wait-tailnet-ip/default.nix
+++ b/pkgs/wait-tailnet-ip/default.nix
@@ -1,0 +1,24 @@
+# Block until tailscaled has assigned this node a tailnet IPv4 (or give up
+# after ~60s). Used as an ExecStartPre gate for services that resolve their
+# own bind address via `tailscale ip -4` at startup. systemd's
+# `After=tailscaled.service` only orders process *spawn*, not readiness — on a
+# deploy that restarts tailscaled, the daemon is "active" several seconds
+# before it has re-established the tunnel and reassigned the IP, so dependent
+# services lose the race and exit 1 with `tailscale ip -4: exit status 1`.
+{ writeShellApplication, tailscale }:
+writeShellApplication {
+  name = "wait-tailnet-ip";
+  runtimeInputs = [ tailscale ];
+  text = ''
+    i=0
+    while [ "$i" -lt 60 ]; do
+      if tailscale ip -4 >/dev/null 2>&1; then
+        exit 0
+      fi
+      i=$((i + 1))
+      sleep 1
+    done
+    echo "wait-tailnet-ip: tailscale ip -4 unavailable after 60s" >&2
+    exit 1
+  '';
+}

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -29,9 +29,13 @@ rollback() {
     local rollback_short
     rollback_short=$(git rev-parse --short "$rollback_rev")
     logger -t "$LOG_TAG" "Rolling back $targets to $rollback_short"
-    git checkout "$rollback_rev"
+    # Send git's own chatter ("Switched to...", "Your branch is up to date...")
+    # to the log, not stdout — this function's stdout is captured into $ROLLED
+    # and interpolated into the failure notification, so it must be the short
+    # rev and nothing else.
+    git checkout "$rollback_rev" 2>&1 | logger -t "$LOG_TAG" || true
     colmena apply --on "$targets" 2>&1 | logger -t "$LOG_TAG" || true
-    git checkout master
+    git checkout master 2>&1 | logger -t "$LOG_TAG" || true
     echo "$rollback_short"
   else
     echo ""
@@ -106,14 +110,49 @@ if [ "$FAILED" = "1" ]; then
 fi
 
 # 4. Deploy saruman (self)
-if colmena apply --on saruman 2>&1 | logger -t "$LOG_TAG"; then
-  logger -t "$LOG_TAG" "Saruman deploy succeeded"
+#
+# colmena exits non-zero (commonly 4) when ANY unit is failed at the
+# activation *snapshot* — even one that systemd's Restart= heals seconds
+# later. saruman runs the MCP/hermes cluster, which briefly fails on a deploy
+# that also restarts tailscaled (see mcp/default.nix), so the bare exit code
+# is a false negative. Judge saruman on the SETTLED state instead: capture the
+# real exit code, and if it's non-zero, distinguish a genuine failure
+# (activation never completed) from a transient flap (activation completed,
+# units heal) by checking for "Activation successful" and then re-running a
+# `systemctl --failed` health check after a grace period.
+SARUMAN_LOG=$(mktemp)
+set +e
+colmena apply --on saruman 2>&1 | tee "$SARUMAN_LOG" | logger -t "$LOG_TAG"
+SARUMAN_RC=${PIPESTATUS[0]}
+set -e
+
+SARUMAN_OK=1
+SARUMAN_REASON=""
+if [ "$SARUMAN_RC" -ne 0 ]; then
+  if ! grep -q "Activation successful" "$SARUMAN_LOG"; then
+    SARUMAN_OK=0
+    SARUMAN_REASON="activation did not complete (colmena rc=$SARUMAN_RC)"
+  else
+    logger -t "$LOG_TAG" "colmena rc=$SARUMAN_RC but activation completed — settling 30s before health check"
+    sleep 30
+    FAILED_UNITS=$(systemctl --failed --no-legend | grep -v 'auto-deploy.service' || true)
+    if [ -n "$FAILED_UNITS" ]; then
+      SARUMAN_OK=0
+      SARUMAN_REASON="units still failed after settle: $(echo "$FAILED_UNITS" | grep -oE '[^[:space:]]+\.(service|socket|timer|target|mount|path)' | tr '\n' ' ')"
+    fi
+  fi
+fi
+rm -f "$SARUMAN_LOG"
+
+if [ "$SARUMAN_OK" = "1" ]; then
+  logger -t "$LOG_TAG" "Saruman deploy succeeded (colmena rc=$SARUMAN_RC)"
 else
+  logger -t "$LOG_TAG" "Saruman deploy FAILED: $SARUMAN_REASON"
   ROLLED=$(rollback "saruman")
   if [ -n "$ROLLED" ]; then
-    curl -s -H "Title: Deploy FAILED" -H "Priority: high" -d "Saruman deploy failed at $SHORT_REV: $COMMIT_MSG. Rolled back to $ROLLED." "$NTFY_URL" || true
+    curl -s -H "Title: Deploy FAILED" -H "Priority: high" -d "Saruman deploy failed at $SHORT_REV ($SARUMAN_REASON): $COMMIT_MSG. Rolled back to $ROLLED." "$NTFY_URL" || true
   else
-    curl -s -H "Title: Deploy FAILED" -H "Priority: high" -d "Saruman deploy failed at $SHORT_REV: $COMMIT_MSG. No known-good revision to roll back to." "$NTFY_URL" || true
+    curl -s -H "Title: Deploy FAILED" -H "Priority: high" -d "Saruman deploy failed at $SHORT_REV ($SARUMAN_REASON): $COMMIT_MSG. No known-good revision to roll back to." "$NTFY_URL" || true
   fi
   exit 1
 fi


### PR DESCRIPTION
## Root cause

Every recurring saruman deploy "failure" traces to one race. Any deploy whose closure restarts `tailscaled` brings down and back up the daemon during activation. The 9 MCP gateways and `hermes-agent` resolve their bind address via `tailscale ip -4` **at service start**, and `After=tailscaled.service` only orders process *spawn*, not readiness — so they start while tailscale is still warming up (`health: "Tailscale is starting"`) and exit 1:

```
vault-mcp / radicale-mcp / gcal-mcp / agent-memory-mcp / email-mcp /
miniflux-mcp / signal-mcp / escalator-mcp / prometheus-mcp:
  ERROR "bind ip" err="tailscale ip -4: exit status 1"
```

`Restart=on-failure` heals them within ~5s, but colmena snapshots the failure and returns **exit 4**. `auto-deploy.sh` (`set -o pipefail`) reads that as a hard failure → rolls back → fires a false high-priority "Deploy FAILED" ntfy → leaves `auto-deploy.service` failed. The commit titled *"stop rollback self-kill"* never touched the exit-code handling.

(The Jun 03 GPU-container `exit 126` failures were the same shape via the nvidia CDI generator during the driver swap; resolved now that 580 is pinned.)

## Fix

1. **`pkgs/wait-tailnet-ip`** — `ExecStartPre` helper that blocks until `tailscale ip -4` succeeds (60s timeout).
2. **`mcp/default.nix`** — inject the gate into every *enabled* MCP unit centrally (one place for the rationale; `mkIf` drops it on hosts that don't run the MCP).
3. **`hermes-agent`** — prepend the gate before the existing signal-cli wait (same race, same established pattern).
4. **`auto-deploy.sh` (saruman step)** — capture colmena's real exit code; on non-zero, distinguish a genuine failure (no `Activation successful` in the log) from a transient flap (activation completed → settle 30s → `systemctl --failed`). Roll back only on a genuine failure.
5. **`auto-deploy.sh` (rollback)** — route `git checkout` chatter to the log so `$ROLLED` is the bare rev, fixing the garbled `Rolled back to Your branch is up to date...` message.

## Validation

- `nix eval` of saruman & atreides toplevels: clean.
- `ExecStartPre` confirmed injected: `agent-memory-mcp` → `[wait-tailnet-ip]`; `hermes-agent` → `[wait-tailnet-ip, wait-for-signal-cli]`.
- atreides (no MCPs): `agent-memory-mcp` unit correctly absent (no empty units from `mkIf false`).
- `pkgs.wait-tailnet-ip` builds (shellcheck passes in checkPhase); `bash -n auto-deploy.sh` clean.

## Out of scope (noted in commit)

The `@vm` deploy step has the same latent exit-code misread but hasn't surfaced (VMs run no tailnet-binding services). Left for a follow-up to keep this scoped to the observed failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)