### PR TITLE
fix(speaches): stop tmpfiles re-chowning the HF cache away from the container

### DIFF
--- a/hosts/common/optional/roles/server/speaches.nix
+++ b/hosts/common/optional/roles/server/speaches.nix
@@ -37,14 +37,19 @@
       extraOptions = [ "--device" "nvidia.com/gpu=all" ];
     };
 
+    # Pre-create the cache dirs so speaches's startup scan_cache_dir() finds
+    # /home/ubuntu/.cache/huggingface/hub (it errors hard with CacheNotFound
+    # otherwise). Ownership is left to podman: the `:U` mount option chowns the
+    # volume to the container's `ubuntu` uid at container start. The owner/group
+    # fields MUST be "-" (leave unmodified on existing inodes) — pinning them to
+    # `ollama` re-chowns the dir away from the container user on every
+    # activation, and since the long-running container isn't restarted by a
+    # `switch`, `:U` doesn't re-apply, so transcriptions then fail with EACCES
+    # reading the cache (the container can't even traverse a 0700 ollama-owned
+    # dir). Mode 0755 is harmless to re-assert; ownership is the part that bites.
     systemd.tmpfiles.rules = [
-      "d /home/ollama/whisper-models 0755 ollama ollama -"
-      # Pre-create the huggingface_hub cache subdir — speaches calls
-      # huggingface_hub.scan_cache_dir() at startup which errors hard
-      # (CacheNotFound) if /home/ubuntu/.cache/huggingface/hub doesn't
-      # exist inside the container. The `:U` mount option chowns both
-      # parent and child to the container user.
-      "d /home/ollama/whisper-models/hub 0755 ollama ollama -"
+      "d /home/ollama/whisper-models 0755 - - -"
+      "d /home/ollama/whisper-models/hub 0755 - - -"
     ];
 
     # Open :8000 on all interfaces — same posture as Kokoro and Ollama


### PR DESCRIPTION
## Problem

OpenWhispr STT was broken: every transcription returned 500 with `PermissionError: [Errno 13] Permission denied: '/home/ubuntu/.cache/huggingface/token'` during model load.

Root cause is a `tmpfiles`-vs-podman-`:U` ownership fight:
- The cache `/home/ollama/whisper-models` is bind-mounted into the container at `~/.cache/huggingface` with `:U`, which chowns it to the container's `ubuntu` uid (host uid 1000 = alex) **at container start**.
- The `systemd.tmpfiles` rules pinned that dir to `ollama:ollama`, re-chowning it **on every nixos activation**.
- A `switch` doesn't restart the long-running container, so `:U` never re-applies. The container is then left facing a `0700 ollama`-owned dir it can't even traverse → EACCES on every cache read.

It bites on every deploy; it surfaced right after the auto-deploy fix (#98) ran an activation. Restarting the container restores access (re-applies `:U`) but the next activation breaks it again.

## Fix

Set the tmpfiles owner/group fields to `-`. Per `tmpfiles.d(5)`, `-` applies ownership only when *creating* a new inode and leaves existing inodes unmodified — so the dirs are still created on a fresh host, but their ownership is handed to podman's `:U` and never clobbered on re-activation. Mode `0755` is harmless to re-assert (the owner keeps full access); ownership was the part that bit.

## Verification

- The live host was already restored manually (`systemctl restart podman-speaches`); a real transcription now succeeds:
  `POST /v1/audio/transcriptions model=Systran/faster-whisper-large-v3 → 200 {"text":...}`.
- This change makes that survive future activations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)