### PR TITLE
fix(hermes): re-seed the morning-brief cron job on boot

### DIFF
--- a/hosts/common/optional/roles/server/hermes-agent/state.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/state.nix
@@ -48,5 +48,45 @@ in
           /var/lib/hermes/.hermes/scripts/morning-today.py
       '';
     };
+
+    # Re-register the morning-brief cron job on every boot. hermes stores
+    # cron jobs in $HERMES_HOME/cron/jobs.json — runtime state under
+    # /var/lib/hermes, which has NO impermanence persistence, so a reboot
+    # wipes it and the daily brief silently stops (it did, 2026-06-06, after
+    # the Jun 3 reboot — `hermes cron list` came back empty). Rather than
+    # persist opaque runtime state, this oneshot is the single Nix-owned
+    # source of truth for the brief schedule, alongside the morning-today.py
+    # copy above. Idempotent (creates only if absent); ordered before the
+    # daemon so it loads a populated jobs.json at start; best-effort (never
+    # fails the boot). Must run as alex with HERMES_HOME set, or the job
+    # lands in the wrong store and the daemon never sees it.
+    systemd.services.hermes-seed-cron = {
+      description = "Register the morning-today daily-brief cron job if absent";
+      after = [ "systemd-tmpfiles-setup.service" ];
+      before = [ "hermes-agent.service" ];
+      wantedBy = [ "multi-user.target" ];
+      environment.HERMES_HOME = "/var/lib/hermes/.hermes";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "alex";
+        Group = "hermes";
+        TimeoutStartSec = 90;
+      };
+      script = ''
+        hermes=${config.services.hermes-agent.package}/bin/hermes
+        if "$hermes" cron list 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q morning-today; then
+          echo "morning-today cron job already registered — nothing to do"
+        else
+          echo "morning-today cron job missing — registering"
+          "$hermes" cron create '0 6 * * *' \
+            --name morning-today \
+            --script morning-today.py \
+            --no-agent \
+            --deliver signal \
+            || echo "WARNING: failed to register morning-today cron job (non-fatal)"
+        fi
+      '';
+    };
   };
 }


### PR DESCRIPTION
## Problem

The daily brief stopped firing. Root cause: hermes stores cron jobs in `$HERMES_HOME/cron/jobs.json` (`/var/lib/hermes/.hermes/cron/`), which has **no impermanence persistence**. The **Jun 3 reboot wiped it** — `hermes cron list` came back empty — and since the schedule isn't seeded declaratively, nothing re-registered it. The 6 AM brief silently died (visible as a gap: no Jun-4th/5th daily notes).

The job was already restored manually (job `7ec251de8fd8`, verified `last_status: ok`), but it would die again on the next reboot. This PR makes it durable.

## Fix

Add `hermes-seed-cron`, a best-effort idempotent oneshot that re-registers the `0 6 * * *` `morning-today` job via the CLI **if it's absent**, ordered `before hermes-agent.service` so the daemon loads a populated `jobs.json` at start.

- **Single source of truth in Nix:** the schedule now lives alongside the `morning-today.py` copy in `state.nix`.
- **Survives reboots *and* state-dir resets** — more robust than persisting the opaque runtime `jobs.json` (which carries per-run timestamps/state and could drift across hermes upgrades).
- Runs as `alex` with `HERMES_HOME` set (per the README gotcha — otherwise the job lands in `/home/alex/.hermes` where the daemon never reads it).
- Never fails the boot: missing-job creation is wrapped `|| echo WARNING`, and the unit exits 0 regardless.

## Validation

- `nix eval` of the saruman toplevel + the new unit: clean.
- The exact CLI invocation was confirmed working live (restored the job, fired today's brief `ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)