### PR TITLE
feat(obsidian-headless): watchdog to restart the sync daemon when wedged

### DIFF
--- a/hosts/common/optional/roles/server/obsidian-headless/default.nix
+++ b/hosts/common/optional/roles/server/obsidian-headless/default.nix
@@ -71,5 +71,47 @@ in
         ReadWritePaths = [ cfg.vaultPath cfg.configDir ];
       };
     };
+
+    # Watchdog. obsidian-headless can hang in a half-open reconnect state
+    # after a brief network drop — the process stays alive (so Restart=
+    # never fires) but stops syncing entirely. Seen 2026-06-04: a ~20s WAN
+    # blip wedged it for 2.5 days, silently, until a manual restart. A
+    # healthy daemon logs ("Fully synced" / "Downloading…" / etc.) roughly
+    # every 30s; a wedged one goes completely silent. So: if the unit is
+    # active but has produced no journal output for 10 minutes, it's stuck —
+    # bounce it. Restarting re-establishes the connection and flushes the
+    # backlog.
+    systemd.services.obsidian-headless-watchdog = {
+      description = "Restart obsidian-headless if it has stopped syncing";
+      path = [ pkgs.systemd ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+      };
+      script = ''
+        if ! systemctl is-active --quiet obsidian-headless.service; then
+          # Not running — its own Restart=/ConditionPathExists govern this.
+          exit 0
+        fi
+        recent=$(journalctl -u obsidian-headless.service --since "10 min ago" \
+                   --no-pager -o cat -q || true)
+        if [ -z "$recent" ]; then
+          echo "obsidian-headless: no log output in 10m while active — wedged, restarting"
+          systemctl restart obsidian-headless.service
+        else
+          echo "obsidian-headless: healthy (logged within last 10m)"
+        fi
+      '';
+    };
+
+    systemd.timers.obsidian-headless-watchdog = {
+      description = "Periodic liveness check for obsidian-headless sync";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "10min";
+        OnUnitActiveSec = "5min";
+        RandomizedDelaySec = "30s";
+      };
+    };
   };
 }


### PR DESCRIPTION
## Problem

`obsidian-headless` can hang in a half-open reconnect state after a brief network drop. The process stays alive — so `Restart=on-failure` never fires — but it stops syncing entirely and logs nothing.

Seen **2026-06-04**: a ~20s WAN blip (tailscale logged IPv6 `network is unreachable`, DERP timeouts) dropped its connection to the Obsidian Sync server at 02:11. It went to `Connecting…` and then **silent for 2.5 days**. Today's daily note never uploaded, and changes from other devices never came down, until a manual restart flushed the backlog.

This is the *process-alive-but-function-dead* failure mode that `Restart=` can't catch.

## Fix

A timer + oneshot watchdog. A healthy daemon logs roughly every 30s (`Fully synced`, or download/upload activity); a wedged one is completely silent. If the unit is **active but has produced no journal output for 10 minutes**, restart it (which re-establishes the connection and flushes the backlog). Polls every 5 minutes → a wedge is caught within ~10–15 min instead of indefinitely.

Liveness is checked by journal output rather than a specific message, so it won't false-restart during a long legitimate backlog sync (that produces continuous log lines), and it's robust to log-message changes.

## Validation

- `nix eval` of the saruman toplevel + the timer/unit: clean.
- The underlying restart action is the exact one that recovered sync today (uploaded `Jun-6th-2026.md`, ended on `Fully synced`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)