### PR TITLE
fix(impermanence): force /var/lib/private to 0700 for DynamicUser StateDirectory

### DIFF
--- a/hosts/common/global/impermanence.nix
+++ b/hosts/common/global/impermanence.nix
@@ -27,6 +27,34 @@
   };
   programs.fuse.userAllowOther = true;
 
+  # systemd ≥256 refuses to set up a DynamicUser StateDirectory if
+  # /var/lib/private is more permissive than 0700 ("Directory /var/lib/private
+  # ... has mode 0755 that is too permissive (0700 was requested), refusing"
+  # → status=238/STATE_DIRECTORY). Under impermanence /var/lib/private is
+  # created as the mount-point parent for the per-service persisted state dirs
+  # (var-lib-private-*.mount) at 0755, and the per-service
+  # `d /var/lib/private 0700` tmpfiles rules don't reliably override it across
+  # the mount boundary. A systemd bump (flake.lock update, 2026-06-07) made
+  # the check strict and silently broke every DynamicUser service on atreides
+  # (otelcol, ntfy, alertmanager, alloy, tempo, …) on next restart. Force the
+  # mode in early boot — after the bind mounts land, before any service
+  # starts. No-op where /var/lib/private doesn't exist.
+  systemd.services.fix-var-lib-private-perms = {
+    description = "Force /var/lib/private to 0700 (systemd DynamicUser requirement)";
+    wantedBy = [ "sysinit.target" ];
+    before = [ "sysinit.target" ];
+    after = [ "local-fs.target" ];
+    unitConfig = {
+      ConditionPathExists = "/var/lib/private";
+      DefaultDependencies = false;
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${pkgs.coreutils}/bin/chmod 0700 /var/lib/private";
+    };
+  };
+
   security.sudo.extraConfig = ''
     # rollback results in sudo lectures after each reboot
     Defaults lecture = never


### PR DESCRIPTION
## Problem

The nightly flake update (`a73e90b`, PR #102) bumped systemd, which now **strictly** requires `/var/lib/private` to be `0700` for any `DynamicUser` + `StateDirectory` service:

```
Directory "/var/lib/private" already exists, but has mode 0755 that is too permissive (0700 was requested), refusing.
Failed at step STATE_DIRECTORY → status=238/STATE_DIRECTORY
```

Under impermanence, `/var/lib/private` is created as the mount-point parent for the per-service persisted state dirs (`var-lib-private-*.mount`) at **0755**, and the per-service `d /var/lib/private 0700` tmpfiles rules don't override it across the mount boundary. Older systemd tolerated this; the new one refuses.

On atreides this broke `opentelemetry-collector` first (its package also bumped → forced restart into the strict check → crash-loop → `start-limit-hit` → colmena exit 4 → the `@vm` deploy step rolled back, i.e. "deployment failing"). Every other DynamicUser service there (`ntfy`, `alertmanager`, `alloy`, `tempo`, `homepage-dashboard`) would have followed on its next restart.

## Fix

An early-boot oneshot (`fix-var-lib-private-perms`) that `chmod 0700 /var/lib/private` **after** the bind mounts land (`after local-fs.target`) and **before** any service starts (`before/wantedBy sysinit.target`, `DefaultDependencies=false`). Guarded by `ConditionPathExists=/var/lib/private`, so it's a no-op on hosts without DynamicUser state. Lives in the global `impermanence.nix` so it protects the whole fleet (and future DynamicUser services), not just atreides.

tmpfiles can't do this reliably (the existing `d 0700` rules already fail to win across the mount boundary), so a chmod ordered explicitly before services is the bulletproof approach.

## Validation

- Confirmed live: `chmod 0700 /var/lib/private` on atreides immediately let `opentelemetry-collector` start (`active`, no failed units), unblocking the deploy.
- `nix eval` of atreides + saruman toplevels: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)