### PR TITLE
fix(otel): migrate removed loki exporter to otlphttp

### DIFF
--- a/hosts/common/optional/roles/server/otel-collector.nix
+++ b/hosts/common/optional/roles/server/otel-collector.nix
@@ -58,8 +58,13 @@
             tls.insecure = true;
           };
 
-          loki = {
-            endpoint = "http://localhost:3100/loki/api/v1/push";
+          # The dedicated `loki` exporter was removed from otelcol-contrib in
+          # 0.151.0. Push logs to Loki's native OTLP endpoint instead (Loki
+          # ≥3.x serves /otlp/v1/logs; otlphttp appends /v1/logs to the
+          # endpoint). allow_structured_metadata is already enabled in loki.nix.
+          "otlphttp/loki" = {
+            endpoint = "http://localhost:3100/otlp";
+            tls.insecure = true;
           };
 
           "otlp/tempo" = {
@@ -93,7 +98,7 @@
             logs = {
               receivers = [ "otlp" ];
               processors = [ "batch" "resource" ];
-              exporters = [ "loki" ];
+              exporters = [ "otlphttp/loki" ];
             };
             traces = {
               receivers = [ "otlp" ];


### PR DESCRIPTION
## Problem

`otelcol-contrib 0.151.0` (from the flake.lock bump) **removed the dedicated `loki` exporter**. `otel-collector.nix` still defined `exporters.loki` and used it in the logs pipeline, so the collector couldn't parse its config:

```
Error: failed to get config: cannot unmarshal the configuration:
'exporters' unknown type: "loki" for id: "loki"
```

→ `status=1` → crash-loop → `start-limit-hit` → colmena exit 4 → the `@vm` deploy step rolled back. This is the current blocker behind the failing hourly deploys (after the `0700`/StateDirectory fix #103 let otelcol get as far as config parsing).

## Fix

Push logs to Loki's **native OTLP endpoint** instead of the removed exporter:

```nix
"otlphttp/loki" = { endpoint = "http://localhost:3100/otlp"; tls.insecure = true; };
...
logs.exporters = [ "otlphttp/loki" ];
```

`otlphttp` appends `/v1/logs` → `http://localhost:3100/otlp/v1/logs`, which I confirmed live on atreides (Loki 3.7.2, `allow_structured_metadata = true` already set). No Loki-side change needed.

## Validation

- `nix eval` of the atreides toplevel: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)