### PR TITLE
feat(hermes): local Qwen aliases — qwen3:4b-instruct (saruman) + Qwen3-Coder (Mac)

### DIFF
--- a/hosts/common/hosts-data.nix
+++ b/hosts/common/hosts-data.nix
@@ -7,6 +7,11 @@
   saruman  = { ip = "10.1.8.6";   role = "server"; tailnetIp = "100.104.242.112"; };
   vader    = { ip = "10.2.1.245"; role = "server"; };
 
+  # Darwin (nix-darwin-managed, not colmena) — roaming laptop, so its only
+  # stable address is the tailnet IP; `ip` mirrors it (no managed LAN IP).
+  # Referenced by hermes-agent for the `/model maccoder` LM Studio alias.
+  faramir  = { ip = "100.90.82.127"; role = "workstation"; tailnetIp = "100.90.82.127"; };
+
   # Infrastructure (not NixOS-managed)
   unifi          = { ip = "10.1.8.1";   role = "infrastructure"; };
   truenas        = { ip = "10.1.8.4";   role = "infrastructure"; };

--- a/hosts/common/optional/roles/darwin/default.nix
+++ b/hosts/common/optional/roles/darwin/default.nix
@@ -18,6 +18,20 @@
         operation; `lms` is a closed-source CLI shipped with the app.
       '';
     };
+    serveHost = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "100.90.82.127";
+      description = ''
+        Bind address for LM Studio's API server (`lms server start --host`).
+        Defaults to loopback. Set to this Mac's *tailnet* IP to expose the
+        endpoint to the tailnet (e.g. so Hermes on saruman can reach it) —
+        NOT 0.0.0.0, since this is a roaming laptop and 0.0.0.0 would expose
+        the unauthenticated API on whatever (possibly untrusted) network it's
+        joined to. When non-loopback, `--cors` is also enabled. Requires
+        LM Studio ≥0.4 for the `--host` flag.
+      '';
+    };
   };
 
   config = {
@@ -73,17 +87,21 @@
 
     launchd.user.agents = lib.optionalAttrs config.lab.lmStudio.autoStart {
       lms-server = {
-        # `lms server start` brings up LM Studio's local API on 127.0.0.1:1234
-        # and exits immediately. If autoLoadModel is set, queue a model load so
-        # the LLM endpoint is warmed up before first request.
+        # `lms server start` brings up LM Studio's local API (default
+        # 127.0.0.1:1234) and exits immediately. If autoLoadModel is set, queue
+        # a model load so the LLM endpoint is warmed up before first request.
+        # When serveHost is non-loopback, bind there + enable CORS so tailnet
+        # clients (e.g. Hermes on saruman) can reach it.
         # KeepAlive disabled — the command is one-shot, not a long-running daemon.
         command =
           let
             lms = "/Users/alex/.lmstudio/bin/lms";
+            hostArg = lib.optionalString (config.lab.lmStudio.serveHost != "127.0.0.1")
+              " --host ${config.lab.lmStudio.serveHost} --cors";
             loadCmd = lib.optionalString (config.lab.lmStudio.autoLoadModel != null)
               " && ${lms} load '${config.lab.lmStudio.autoLoadModel}'";
           in
-          "/bin/sh -c '${lms} server start${loadCmd}'";
+          "/bin/sh -c '${lms} server start${hostArg}${loadCmd}'";
         serviceConfig = {
           RunAtLoad = true;
           KeepAlive = false;

--- a/hosts/common/optional/roles/server/hermes-agent/default.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/default.nix
@@ -62,12 +62,13 @@ in
 
     localModel = lib.mkOption {
       type = lib.types.str;
-      default = "gemma4-8b-16k";
+      default = "qwen3:4b-instruct-28k";
       description = ''
-        Ollama tag for the local Gemma model accessible via the
-        `/model local` alias. Modelfile-wrapped from gemma4:latest
-        with num_ctx=16384 baked in (32K spilled to CPU and tanked
-        latency).
+        Ollama tag for the local model accessible via the `/model local`
+        alias, served on saruman's GTX 1080 Ti. Qwen3 4B Instruct
+        (28K ctx, tool-use, non-thinking) — fits comfortably in VRAM and
+        is well-suited to fast tool-calling agent turns. Replaced the
+        retired gemma4-8b-16k wrapper 2026-06-16.
       '';
     };
 
@@ -81,6 +82,31 @@ in
       type = lib.types.str;
       default = "ollama";
       description = "API key for local Ollama (Ollama doesn't validate; sentinel).";
+    };
+
+    # ── Mac (faramir) LM Studio — `/model maccoder` ──
+    macCoderModel = lib.mkOption {
+      type = lib.types.str;
+      default = "qwen3-coder-30b-a3b-instruct-mlx";
+      description = ''
+        LM Studio model identifier served on faramir (the Mac) via the
+        `/model maccoder` alias. Qwen3-Coder-30B-A3B-Instruct (MLX 4-bit) —
+        a coding/agentic model far beyond what the 1080 Ti can host.
+        Requires LM Studio on faramir to be serving on the local network
+        (not loopback-only) and the Mac to be awake.
+      '';
+    };
+
+    macCoderBaseUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://${config.lab.hosts.faramir.tailnetIp}:1234/v1";
+      description = "Base URL of faramir's LM Studio OpenAI-compatible endpoint over the tailnet.";
+    };
+
+    macCoderApiKey = lib.mkOption {
+      type = lib.types.str;
+      default = "lm-studio";
+      description = "API key for faramir's LM Studio (not validated; sentinel).";
     };
 
     sessionIdleMinutes = lib.mkOption {

--- a/hosts/common/optional/roles/server/hermes-agent/service.nix
+++ b/hosts/common/optional/roles/server/hermes-agent/service.nix
@@ -185,16 +185,28 @@ in
           };
 
           # ── Local Ollama alias ──
-          # `/model local` swaps to Gemma 4 8B on saruman's GTX 1080
-          # Ti. Free, private (prompts never leave the box). Useful
-          # for low-stakes chitchat or when you want to keep tokens
-          # out of OR. Capabilities are limited at 8B — don't expect
-          # the depth of V4 Pro.
+          # `/model local` swaps to Qwen3 4B Instruct on saruman's GTX
+          # 1080 Ti. Free, private (prompts never leave the box), and
+          # tool-use capable. Useful for low-stakes turns or to keep
+          # tokens out of OR. Limited depth at 4B — don't expect V4 Pro.
           local = {
             model = cfg.localModel;
             provider = "custom";
             base_url = cfg.localBaseUrl;
             api_key = cfg.localApiKey;
+          };
+
+          # ── Mac LM Studio alias ──
+          # `/model maccoder` routes to Qwen3-Coder-30B (MLX) on faramir
+          # over the tailnet. Far more capable than the 1080 Ti's local
+          # model for coding/agentic work, still private to the tailnet.
+          # Inert unless faramir is awake AND LM Studio is serving on the
+          # network (not loopback) — see macCoder* options in default.nix.
+          maccoder = {
+            model = cfg.macCoderModel;
+            provider = "custom";
+            base_url = cfg.macCoderBaseUrl;
+            api_key = cfg.macCoderApiKey;
           };
 
         };

--- a/hosts/faramir/configuration.nix
+++ b/hosts/faramir/configuration.nix
@@ -9,6 +9,11 @@
 
   lab.lmStudio.autoStart = true;
   lab.lmStudio.autoLoadModel = "qwen3-coder-30b-a3b-instruct-mlx";
+  # Serve the LM Studio API on faramir's tailnet IP (not 0.0.0.0) so Hermes
+  # on saruman can reach Qwen3-Coder via `/model maccoder`, without exposing
+  # the unauthenticated endpoint on untrusted networks the laptop roams onto.
+  # Mirrors faramir's tailnetIp in hosts-data.nix (darwin lacks lab.hosts).
+  lab.lmStudio.serveHost = "100.90.82.127";
 
   # Homebrew declaration for faramir. The darwin role pins
   # `homebrew.onActivation.cleanup = "none"`, so this list is treated as


### PR DESCRIPTION
Aligns Hermes's local model options with what's actually running locally.

## Changes
- **`/model local` → `qwen3:4b-instruct-28k`** on saruman (was `gemma4-8b-16k`, which had been deleted — the alias was 404ing). Instruct-tuned, tool-use, 28k ctx, comfortable on the 1080 Ti.
- **New `/model maccoder` → `qwen3-coder-30b-a3b-instruct-mlx`** served by LM Studio on faramir (Mac), over the tailnet. Far beyond what the GPU can host; private to the tailnet.

## Supporting
- **`hosts-data.nix`**: add `faramir` (workstation, tailnet IP) so the alias resolves via `config.lab.hosts` (no hardcoded IP). Safe — prometheus/smokeping/blocky reference hosts *by name*, none iterate the attrset.
- **darwin `lab.lmStudio.serveHost`**: faramir binds LM Studio to its **tailnet IP** (not `0.0.0.0` — roaming laptop) + `--cors`. Requires LM Studio ≥0.4.

## Validation
- `nix eval`: saruman toplevel + faramir darwin-system both build clean.

## ⚠️ Manual step (Mac — not auto-deployable)
faramir has Remote Login off; darwin deploys via `mac-rebuild`. After merge, on the Mac: `mac-rebuild`, then verify `curl http://100.90.82.127:1234/v1/models` from saruman. The `/model maccoder` alias is inert until then (and whenever the Mac sleeps) — errors harmlessly, no effect on the default. `/model local` works as soon as this deploys to saruman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)