### PR TITLE
fix(signal-cli): run prebuilt 0.14.5 native binary to fix sealed-sender NPE

### DIFF
--- a/hosts/common/optional/roles/server/signal-cli.nix
+++ b/hosts/common/optional/roles/server/signal-cli.nix
@@ -1,14 +1,15 @@
 { lib, pkgs, config, ... }:
 let
   cfg = config.signal-cli;
-  # Track signal-cli from unstable (0.14.3) rather than the pinned nixpkgs
-  # (0.14.2): 0.14.2 throws `getServerGuid(...) must not be null`
-  # (NullPointerException) decoding some sealed-sender envelopes ("unknown
-  # source") and drops them before they reach Hermes — so inbound messages
-  # silently vanish. First seen 2026-06-10. 0.14.3 is the cheap first attempt;
-  # the symptom most closely matches 0.14.4's "fixing receiving messages from
-  # new contacts", so if this doesn't clear it, bump to a 0.14.4.x override.
-  signalCli = pkgs.unstable.signal-cli;
+  # signal-cli 0.14.5 via the prebuilt GraalVM native release (pkgs.signal-cli-bin).
+  # A Signal server-side change (~2026-06-10) broke sealed-sender receive in
+  # every signal-cli < 0.14.5 with `getServerGuid(...) must not be null`
+  # (NullPointerException, upstream #2059) — inbound messages silently vanished
+  # before reaching Hermes. nixpkgs lags at 0.14.3 (source build), and 0.14.3
+  # was confirmed still broken, so we run the upstream 0.14.5 binary as a
+  # stopgap. REVERT to pkgs.signal-cli (or pkgs.unstable.signal-cli) once
+  # nixpkgs ships >= 0.14.5; see pkgs/signal-cli-bin for the full rationale.
+  signalCli = pkgs.signal-cli-bin;
   # Wrapper that locks in the same data directory the daemon uses.
   # Without this, ad-hoc `sudo -u hermes signal-cli ...` invocations fall back
   # to the user-default `~/.local/share/signal-cli/`, which diverges from the

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -22,4 +22,5 @@
   hermes-skill-obsidian = pkgs.callPackage ./hermes-skill-obsidian { };
   openwhispr = pkgs.callPackage ./openwhispr { };
   wait-tailnet-ip = pkgs.callPackage ./wait-tailnet-ip { };
+  signal-cli-bin = pkgs.callPackage ./signal-cli-bin { };
 }

--- a/pkgs/signal-cli-bin/default.nix
+++ b/pkgs/signal-cli-bin/default.nix
@@ -1,0 +1,54 @@
+# Prebuilt signal-cli from the upstream GraalVM native release.
+#
+# Stopgap: nixpkgs builds signal-cli from source and lags upstream by ~2
+# months (stuck at 0.14.3 as of 2026-06-16). A Signal server-side envelope
+# change (~2026-06-10) broke sealed-sender receive in every signal-cli
+# < 0.14.5 with `getServerGuid(...) must not be null` (NullPointerException,
+# upstream #2059), so inbound messages silently vanish before reaching Hermes.
+# 0.14.5 (released 2026-06-11) is the fix.
+#
+# Rather than forward-port the source build (regenerate the Gradle deps.json +
+# rebuild the libsignal Rust JNI), we wrap the official `-Linux-native.tar.gz`:
+# a single GraalVM-compiled ELF (no JRE, no sidecar libsignal — it's baked into
+# the image), dynamically linked against only libc + libz. autoPatchelfHook
+# fixes the interpreter/rpath for NixOS.
+#
+# REMOVE this and revert hosts/.../signal-cli.nix to pkgs.signal-cli once
+# nixpkgs ships >= 0.14.5 (the module already tracked unstable, so a flake
+# update will carry the proper source build forward).
+{ lib, stdenv, fetchurl, autoPatchelfHook, zlib }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "signal-cli-bin";
+  version = "0.14.5";
+
+  src = fetchurl {
+    url = "https://github.com/AsamK/signal-cli/releases/download/v${finalAttrs.version}/signal-cli-${finalAttrs.version}-Linux-native.tar.gz";
+    hash = "sha256-OdyeSD2g1pFRBl6HruhIbXqLxn4NPpmUyFEmnBv9gOM=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ (lib.getLib stdenv.cc.cc) zlib ];
+
+  # Tarball is a single bare executable named `signal-cli`, not a directory.
+  sourceRoot = ".";
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 signal-cli $out/bin/signal-cli
+    runHook postInstall
+  '';
+
+  # GraalVM image is already optimized/stripped; don't let fixup re-strip.
+  dontStrip = true;
+
+  meta = {
+    description = "signal-cli ${finalAttrs.version} (prebuilt GraalVM native; stopgap until nixpkgs ships >= 0.14.5)";
+    homepage = "https://github.com/AsamK/signal-cli";
+    license = lib.licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "signal-cli";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Problem
A Signal **server-side** change (~2026-06-10) broke sealed-sender receive in every signal-cli **< 0.14.5** — `getServerGuid(...) must not be null` (NullPointerException, upstream [#2059](https://github.com/AsamK/signal-cli/issues/2059)). signal-cli drops the envelope before it reaches Hermes, so inbound Signal messages silently vanish and Hermes looks dead.

Not a version regression — the same 0.14.2 binary worked through Jun 9, broke Jun 10. Confirmed: **0.14.3** still broken (tested live), **0.14.4.1** also affected. **0.14.5** (Jun 11) is the fix.

## Why prebuilt
nixpkgs lags at **0.14.3** on every branch (source build, ~2 months behind). Forward-porting the source build = regenerate the Gradle `deps.json` **and** rebuild the libsignal Rust JNI (new cargoHash) — maintainer-grade. Instead this wraps the official **`-Linux-native.tar.gz`**: a single GraalVM ELF (no JRE, libsignal baked into the image), dynamically linked against only `libc` + `libz`, patched via `autoPatchelfHook`. ~40-line overlay.

## Changes
- New `pkgs/signal-cli-bin` — fetches + autoPatchelfs the 0.14.5 native binary.
- `signal-cli.nix`: `signalCli` binding → `pkgs.signal-cli-bin` (daemon + wrapper + systemPackages).

## Validation
- Builds; `$out/bin/signal-cli --version` → `signal-cli 0.14.5` (patchelf OK, native binary runs).
- `nix eval` saruman toplevel clean; daemon ExecStart points at the 0.14.5 binary.
- **Real test pending:** an inbound Signal message after deploy (does the NPE clear?).

## Stopgap / revert
Tracked as temporary. Revert to `pkgs.signal-cli` once nixpkgs ships ≥ 0.14.5; the module already tracked unstable so a flake update carries the proper source build forward. Rationale documented in `pkgs/signal-cli-bin/default.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)