### PR TITLE
fix(signal-cli-bin): JRE dist + patched libsignal .so (native image didn't load on NixOS)

### DIFF
--- a/pkgs/signal-cli-bin/default.nix
+++ b/pkgs/signal-cli-bin/default.nix
@@ -1,54 +1,73 @@
-# Prebuilt signal-cli from the upstream GraalVM native release.
+# Prebuilt signal-cli 0.14.5 from the upstream JRE release, with the bundled
+# libsignal-client native .so patched for NixOS.
 #
-# Stopgap: nixpkgs builds signal-cli from source and lags upstream by ~2
-# months (stuck at 0.14.3 as of 2026-06-16). A Signal server-side envelope
-# change (~2026-06-10) broke sealed-sender receive in every signal-cli
-# < 0.14.5 with `getServerGuid(...) must not be null` (NullPointerException,
-# upstream #2059), so inbound messages silently vanish before reaching Hermes.
-# 0.14.5 (released 2026-06-11) is the fix.
+# Stopgap: nixpkgs builds signal-cli from source and lags upstream ~2 months
+# (stuck at 0.14.3 as of 2026-06-16). A Signal server-side envelope change
+# (~2026-06-10) broke sealed-sender receive in every signal-cli < 0.14.5 with
+# `getServerGuid(...) must not be null` (NullPointerException, upstream #2059),
+# so inbound messages silently vanish before reaching Hermes. 0.14.5
+# (2026-06-11) is the fix.
 #
-# Rather than forward-port the source build (regenerate the Gradle deps.json +
-# rebuild the libsignal Rust JNI), we wrap the official `-Linux-native.tar.gz`:
-# a single GraalVM-compiled ELF (no JRE, no sidecar libsignal — it's baked into
-# the image), dynamically linked against only libc + libz. autoPatchelfHook
-# fixes the interpreter/rpath for NixOS.
+# Forward-porting the nixpkgs *source* build would mean regenerating the Gradle
+# deps.json AND rebuilding the libsignal Rust JNI (0.94.4, new cargoHash).
+# Instead we wrap the upstream JRE distribution: it ships every jar including
+# libsignal-client-0.94.4.jar, which bundles `libsignal_jni_amd64.so`. That
+# .so is extracted to /tmp and dlopen'd at runtime, and on NixOS it fails to
+# load (its NEEDED libstdc++/libgcc_s/libm/libc/ld-linux aren't on the default
+# search path). We extract it, let autoPatchelfHook set its rpath, re-inject it
+# into the jar, and run the launcher under a Nix JDK.
 #
 # REMOVE this and revert hosts/.../signal-cli.nix to pkgs.signal-cli once
 # nixpkgs ships >= 0.14.5 (the module already tracked unstable, so a flake
 # update will carry the proper source build forward).
-{ lib, stdenv, fetchurl, autoPatchelfHook, zlib }:
+{ lib, stdenv, fetchurl, autoPatchelfHook, makeWrapper, unzip, zip, jdk25_headless }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-cli-bin";
   version = "0.14.5";
+  libsignalJar = "libsignal-client-0.94.4.jar";
 
   src = fetchurl {
-    url = "https://github.com/AsamK/signal-cli/releases/download/v${finalAttrs.version}/signal-cli-${finalAttrs.version}-Linux-native.tar.gz";
-    hash = "sha256-OdyeSD2g1pFRBl6HruhIbXqLxn4NPpmUyFEmnBv9gOM=";
+    url = "https://github.com/AsamK/signal-cli/releases/download/v${finalAttrs.version}/signal-cli-${finalAttrs.version}.tar.gz";
+    hash = "sha256-YtOOv+85iNePQ35zKBg7de5UnRETguZsGvcNPr0816c=";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ (lib.getLib stdenv.cc.cc) zlib ];
-
-  # Tarball is a single bare executable named `signal-cli`, not a directory.
-  sourceRoot = ".";
-  dontBuild = true;
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper unzip zip ];
+  # Libraries the bundled libsignal_jni_amd64.so needs (autoPatchelfHook
+  # resolves libstdc++/libgcc_s from the gcc lib, libm/libc/ld-linux from glibc).
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 signal-cli $out/bin/signal-cli
+    mkdir -p $out/share/signal-cli
+    cp -r bin lib man $out/share/signal-cli/
+
+    # Stage the native lib loose so fixupPhase's autoPatchelfHook rewrites its
+    # rpath; postFixup re-injects it into the jar.
+    mkdir -p $out/.jni
+    unzip -o -q "$out/share/signal-cli/lib/${finalAttrs.libsignalJar}" \
+      libsignal_jni_amd64.so -d $out/.jni
     runHook postInstall
   '';
 
-  # GraalVM image is already optimized/stripped; don't let fixup re-strip.
-  dontStrip = true;
+  postFixup = ''
+    # Re-inject the now-patched .so at the same path inside the jar (zip -j
+    # would strip the path; we run from $out/.jni so the stored name is bare,
+    # matching its jar-root location).
+    ( cd $out/.jni && zip -q "$out/share/signal-cli/lib/${finalAttrs.libsignalJar}" libsignal_jni_amd64.so )
+    rm -rf $out/.jni
+
+    # Launcher needs a JRE; pin JAVA_HOME to a Nix JDK (signal-cli requires 21+).
+    makeWrapper $out/share/signal-cli/bin/signal-cli $out/bin/signal-cli \
+      --set JAVA_HOME ${jdk25_headless.home}
+  '';
 
   meta = {
-    description = "signal-cli ${finalAttrs.version} (prebuilt GraalVM native; stopgap until nixpkgs ships >= 0.14.5)";
+    description = "signal-cli ${finalAttrs.version} (prebuilt JRE dist, libsignal .so patched for NixOS; stopgap until nixpkgs ships >= 0.14.5)";
     homepage = "https://github.com/AsamK/signal-cli";
     license = lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
     mainProgram = "signal-cli";
-    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode lib.sourceTypes.binaryNativeCode ];
   };
 })


### PR DESCRIPTION
Follow-up to #112, which deployed but **failed to activate** — the GraalVM "native" build still extracts `libsignal_jni_amd64.so` to /tmp and dlopen's it at runtime, and that `.so` fails on NixOS (`Missing required native library`). signal-cli crash-looped; the hardened auto-deploy caught `rc=1` and rolled back to 0.14.3 (no harm).

## Rework
Wrap the **JRE distribution** instead of the native image:
- Extract the bundled `libsignal_jni_amd64.so` from `libsignal-client-0.94.4.jar`.
- `autoPatchelfHook` fixes its rpath (libstdc++/libgcc_s from gcc lib; libm/libc/ld-linux from glibc).
- Re-inject the patched `.so` into the jar.
- Run the launcher under **`jdk25_headless`** — 0.14.5 is compiled for Java 25 (class-file 69.0); jdk21 throws `UnsupportedClassVersionError`.

## Validation (local, x86_64-linux)
- `signal-cli --version` → `signal-cli 0.14.5`
- Daemon starts, `HttpServerHandler - Started HTTP server`, **no** `Missing required native library` — libsignal loads.

Still a stopgap; revert to `pkgs.signal-cli` once nixpkgs ships ≥ 0.14.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)